### PR TITLE
Add coderabbit config and clean up configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,266 @@
+# CodeRabbit Configuration for Crossplane
+# This configuration is optimized for the Crossplane Go project
+
+# =============================================================================
+# GLOBAL SETTINGS
+# =============================================================================
+
+# Language for CodeRabbit reviews and comments (default: en-US, keeping explicit)
+language: "en-US"
+
+# Instructions for CodeRabbit's tone and style in reviews (max 250 chars)
+tone_instructions: |
+  Be collaborative and supportive. Ask clarifying questions rather than making
+  assumptions. Focus on the 'why' behind decisions. Frame concerns
+  constructively and thank contributors.
+
+# Disable early-access features for stability
+early_access: false
+
+# =============================================================================
+# REVIEWS
+# =============================================================================
+
+reviews:
+  # We tested assertive and found it too verbose, e.g. approxing 200 comments on
+  # https://github.com/crossplane/crossplane/pull/6777. Some of the nitpicks do
+  # look valuable to me, but the signal to noise ratio isn't good enough.
+  profile: "chill"
+
+  # Don't generate summary in PR description - let authors write their own
+  high_level_summary: false
+
+  # Include the high-level summary in the walkthrough comment instead
+  high_level_summary_in_walkthrough: true
+
+  # Collapse walkthrough comment to reduce visual clutter in PRs
+  collapse_walkthrough: true
+
+  # Automatically apply labels (disabled - let maintainers control)
+  auto_apply_labels: false
+
+  # Automatically assign suggested reviewers (disabled - let maintainers control)
+  auto_assign_reviewers: false
+
+  # Disable poem generation in walkthrough comments
+  poem: false
+
+  # Disable review status messages to reduce comment noise
+  review_status: false
+
+  # Focus reviews on source code, exclude generated and vendor files
+  path_filters:
+    # Include source code
+    - "**/*.go"
+    - "**/*.yaml"
+    - "**/*.yml"
+    - "**/*.md"
+    - "**/*.proto"
+    - "**/Dockerfile*"
+    - "**/flake.nix"
+    - "**/*.sh"
+
+    # Exclude generated and vendor files
+    - "!**/zz_generated*.go"
+    - "!**/vendor/**"
+    - "!**/node_modules/**"
+    - "!**/*.pb.go"
+    - "!**/*.pb.gw.go"
+    - "!**/mock_*.go"
+    - "!**/fake/**"
+    - "!**/testdata/**"
+    - "!**/dist/**"
+    - "!**/build/**"
+
+  # Path-specific instructions for different areas of the codebase
+  path_instructions:
+    - path: "**/*.go"
+      instructions: |
+        Enforce Crossplane-specific patterns: Use crossplane-runtime/pkg/errors
+        for wrapping. Check variable naming (short for local scope, descriptive
+        for wider scope). Ensure 'return early' pattern. Verify error scoping
+        (declare in conditionals when possible). For nolint directives, require
+        specific linter names and explanations. CRITICAL: Ensure all error
+        messages are meaningful to end users, not just developers - avoid
+        technical jargon, include context about what the user was trying to do,
+        and suggest next steps when possible.
+
+    - path: "**/*_test.go"
+      instructions: |
+        Enforce table-driven test structure: PascalCase test names (no
+        underscores), args/want pattern, use cmp.Diff with
+        cmpopts.EquateErrors() for error testing. Check for proper test case
+        naming and reason fields. Ensure no third-party test frameworks (no
+        Ginkgo, Gomega, Testify).
+
+    - path: "**/*.md"
+      instructions: |
+        Ensure Markdown files are wrapped at 100 columns for consistency and
+        readability. Lines can be longer if it makes links more readable, but
+        otherwise should wrap at 100 characters. Check for proper heading
+        structure, clear language, and that documentation is helpful for users.
+
+    - path: "**/apis/**"
+      instructions: |
+        Focus on API design following Kubernetes API conventions from
+        https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md.
+        Check for proper field naming (camelCase), appropriate types, validation
+        tags, and documentation. Ask about backward compatibility and the impact
+        on existing users and upgrade paths. Consider if changes need feature
+        gates or alpha/beta graduation. Ensure error messages in validation are
+        user-friendly. Pay attention to API consistency, proper use of optional
+        vs required fields, and following established Kubernetes patterns.
+
+    - path: "**/cmd/**"
+      instructions: |
+        Review CLI commands for proper flag handling, help text, and error
+        messages. Ensure commands follow Crossplane CLI conventions. Ask about
+        backward compatibility and user experience. CLI error messages must be
+        especially user-friendly - avoid internal error details, provide
+        actionable guidance.
+
+    - path: "**/test/**"
+      instructions: |
+        Focus on test coverage, test clarity, and proper use of testing
+        utilities. Ask about testing scenarios and edge cases. Ensure tests are
+        maintainable and cover the happy path and error conditions. Verify
+        error testing uses proper patterns (cmpopts.EquateErrors, sentinel
+        errors for complex cases).
+
+    - path: "**/design/**"
+      instructions: |
+        Focus on architectural decisions, user experience, and long-term
+        maintainability. Ask clarifying questions about design choices and
+        consider alternative approaches. Ensure the design aligns with
+        Crossplane's principles and provides good user experience.
+
+  # Automatic review settings
+  auto_review:
+    # Skip reviewing draft PRs until they're ready for review (default: false, keeping explicit)
+    drafts: false
+
+    # Skip reviews if PR title contains these keywords (case-insensitive)
+    ignore_title_keywords:
+      - "wip"
+      - "draft"
+      - "do not merge"
+      - "dnm"
+
+    # Skip reviews from these automated bot accounts
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "renovate[bot]"
+      - "github-actions[bot]"
+
+  # Quality gates that run during CodeRabbit's review to check PR readiness
+  pre_merge_checks:
+    # Check PR title for length and descriptiveness
+    title:
+      requirements: "Keep under 72 characters and be descriptive about what the change does."
+
+    # Disable docstring coverage check (too noisy for Go projects)
+    docstrings:
+      mode: "off"
+
+    # Custom checks specific to Crossplane development practices
+    custom_checks:
+      - name: "Breaking Changes"
+        mode: "error"
+        instructions: |
+          "Fails if files under 'apis/**' or 'cmd/**' remove or rename public
+          fields/flags, add new required public fields/flags, or remove behavior
+          without label 'breaking-change'.
+
+      - name: "Feature Gate Requirement"
+        mode: "error"
+        instructions: |
+          Fails if new experimental features that affect apis/**, or
+          significantly affect behavior, are added without a feature flag
+          implementation.
+
+  # Disable automatic code generation features
+  finishing_touches:
+    # Disable automatic docstring generation
+    docstrings:
+      enabled: false
+
+    # Disable automatic unit test generation
+    unit_tests:
+      enabled: false
+
+  # Tools - DISABLED: We prefer to run linting tools directly in CI
+  # Our comprehensive golangci-lint setup with "default: all" already covers
+  # most static analysis. Additional tools can be added to CI as needed.
+  tools:
+    # Go linting - disabled (we run golangci-lint with comprehensive config)
+    golangci-lint:
+      enabled: false
+
+    # Security and vulnerability scanning - disabled (prefer direct CI integration)
+    gitleaks:
+      enabled: false
+
+    semgrep:
+      enabled: false
+
+    osvScanner:
+      enabled: false
+
+    # File format linting - disabled (prefer direct CI integration)
+    yamllint:
+      enabled: false
+
+    markdownlint:
+      enabled: false
+
+    shellcheck:
+      enabled: false
+
+    hadolint:
+      enabled: false
+
+    actionlint:
+      enabled: false
+
+    buf:
+      enabled: false
+
+    # GitHub integration - disabled for now
+    github-checks:
+      enabled: false
+
+# =============================================================================
+# ISSUE ENRICHMENT
+# Disable automatic issue enrichment (beta feature) - we only want PR reviews
+# =============================================================================
+
+issue_enrichment:
+  auto_enrich:
+    enabled: false
+
+# =============================================================================
+# CHAT
+# Interactive chat with CodeRabbit in PR comments. You can ask questions like:
+# - @coderabbitai explain this error handling approach
+# - @coderabbitai what are the edge cases for this function?
+# - @coderabbitai how does this affect backward compatibility?
+# - @coderabbitai generate unit tests for this function
+# =============================================================================
+
+chat:
+  # Disable ASCII/emoji art in responses
+  art: false
+
+# =============================================================================
+# KNOWLEDGE BASE
+# =============================================================================
+
+knowledge_base:
+  # Learn from Crossplane's coding guidelines and apply them during reviews
+  code_guidelines:
+    filePatterns:
+      - "CONTRIBUTING.md"
+
+  # Enable MCP integration to provide context about external libraries and APIs
+  mcp:
+    usage: "enabled"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,17 +176,3 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
           AWS_DEFAULT_REGION: us-east-1
         run: nix run --option warn-dirty false .#promote-artifacts -- main "$VERSION" master
-
-  # Protobuf schema linting (unchanged from original)
-  protobuf-schemas:
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Lint and Push Protocol Buffers
-        uses: bufbuild/buf-action@8f4a1456a0ab6a1eb80ba68e53832e6fcfacc16c # v1
-        with:
-          token: ${{ secrets.BUF_TOKEN }}
-          pr_comment: false

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,6 +17,6 @@
 # See also OWNERS.md for governance details
 
 # Fallback owners
-*                                   @crossplane/crossplane-maintainers
+*                                   @crossplane/crossplane-maintainers @jcogilvie @tampakrap
 
 # Specific owners may be added here as we determine areas of expertise/ownership.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See Crossplane's [contributing](https://github.com/crossplane/crossplane/tree/main/contributing).


### PR DESCRIPTION
### Description of your changes

Three small changes to our repository configuration:

1. Add a coderabbit config based on Crossplane's. We'll get coderabbit running on this repository once this is merged.
2. Add @jcogilvie and @tampakrap to the CODEOWNERS file.
3. Stop linting protobufs and pushing them to the Buf schema registry. Our protos are vendored from crossplane/crossplane where they are linted and pushed.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation configuration
  * Removed protobuf schema validation from CI workflow
  * Updated code ownership assignments

* **Documentation**
  * Updated contributing guidelines with reference to official documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->