### PR TITLE
fix(config): Fix flag parsing with space-separated value

### DIFF
--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -142,6 +142,9 @@ func configFlag(args []string) (string, error) {
 		}
 
 		if v, ok := strings.CutPrefix(a, "--config="); ok {
+			if v == "" {
+				return "", errors.New("flag --config requires a value")
+			}
 			return v, nil
 		}
 

--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -141,7 +141,7 @@ func configFlag(args []string) (string, error) {
 			continue
 		}
 
-		if v := strings.TrimPrefix(a, "--config="); v != "" {
+		if v, ok := strings.CutPrefix(a, "--config="); ok {
 			return v, nil
 		}
 

--- a/cmd/crossplane/main_test.go
+++ b/cmd/crossplane/main_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestConfigFlag(t *testing.T) {
+	type want struct {
+		path string
+		err  error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   []string
+		want   want
+	}{
+		"Empty": {
+			reason: "No args should yield no path and no error.",
+			args:   nil,
+		},
+		"NoConfigFlag": {
+			reason: "Argv without --config should yield no path and no error.",
+			args:   []string{"version"},
+		},
+		"EqualsForm": {
+			reason: "--config=PATH should return PATH.",
+			args:   []string{"--config=/tmp/config.yaml"},
+			want:   want{path: "/tmp/config.yaml"},
+		},
+		"SpaceForm": {
+			reason: "--config PATH should return PATH from the next argv.",
+			args:   []string{"--config", "/tmp/config.yaml"},
+			want:   want{path: "/tmp/config.yaml"},
+		},
+		"EmptyEquals": {
+			reason: "--config= is an explicitly empty value and should return an error.",
+			args:   []string{"--config="},
+			want:   want{err: cmpopts.AnyError},
+		},
+		"MissingValue": {
+			reason: "Trailing --config with no following argv should return an error.",
+			args:   []string{"--config"},
+			want:   want{err: cmpopts.AnyError},
+		},
+		"FirstWins": {
+			reason: "If --config appears more than once, the first occurrence wins.",
+			args:   []string{"--config=/first.yaml", "--config=/second.yaml"},
+			want:   want{path: "/first.yaml"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := configFlag(tc.args)
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nconfigFlag(%v): -want err, +got err:\n%s", tc.reason, tc.args, diff)
+			}
+			if diff := cmp.Diff(tc.want.path, got); diff != "" {
+				t.Errorf("\n%s\nconfigFlag(%v): -want, +got:\n%s", tc.reason, tc.args, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

While reviewing/testing #3 I noticed that the space-separated `--config /path/to/config.yaml` ignores the config. Reproducer:

```bash
# Create a new config file
go run ./cmd/crossplane --config=/tmp/xpcfg.yaml config set features.enableAlpha true

# Correctly prints the full content of the config
go run ./cmd/crossplane --config=/tmp/xpcfg.yaml config view

# (before the fix) prints only "version: 1" ignoring the config
go run ./cmd/crossplane --config /tmp/xpcfg.yaml config view
```

The problem is that `strings.TrimPrefix` returns the original string unchanged when the prefix doesn't match, so the `v != ""` check can not distinguish "prefix matched and value extracted" from "prefix not matched". For `--config /path` this makes `configFlag` return "--config" as the path instead of falling through to read the next argument.

Switching to `strings.CutPrefix`, which returns an ok bool that makes the distinction clear.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
