### PR TITLE
feat(xr): Convert a Claim to XR via `crossplane xr generate`

### DIFF
--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/crossplane/cli/v2/cmd/crossplane/resource"
 	"github.com/crossplane/cli/v2/cmd/crossplane/version"
 	"github.com/crossplane/cli/v2/cmd/crossplane/xpkg"
+	"github.com/crossplane/cli/v2/cmd/crossplane/xr"
 	"github.com/crossplane/cli/v2/cmd/crossplane/xrd"
 	"github.com/crossplane/cli/v2/internal/config"
 	"github.com/crossplane/cli/v2/internal/maturity"
@@ -83,6 +84,7 @@ type cli struct {
 	Resource    resource.Cmd    `cmd:"" help:"Work with Crossplane resources."                                          maturity:"beta"`
 	Version     version.Cmd     `cmd:"" help:"Print the client and server version information for the current context."`
 	XPKG        xpkg.Cmd        `cmd:"" help:"Work with Crossplane packages."`
+	XR          xr.Cmd          `cmd:"" help:"Work with Crossplane Composite Resources (XRs)."                          maturity:"alpha"`
 	XRD         xrd.Cmd         `cmd:"" help:"Work with Crossplane Composite Resource Definitions (XRDs)."              maturity:"beta"`
 
 	// Hidden top-level alias for render, since it's GA but has moved.

--- a/cmd/crossplane/xr/generate.go
+++ b/cmd/crossplane/xr/generate.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xr
+
+import (
+	"github.com/alecthomas/kong"
+	"github.com/spf13/afero"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apiserver/pkg/storage/names"
+	"sigs.k8s.io/yaml"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/fieldpath"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource/unstructured/composite"
+
+	commonIO "github.com/crossplane/cli/v2/cmd/crossplane/convert/io"
+
+	_ "embed"
+)
+
+//go:embed help/generate.md
+var generateHelp string
+
+type generateCmd struct {
+	// Arguments.
+	InputFile string `arg:"" default:"-" help:"The Claim YAML file to convert, or '-' for stdin." optional:"" predictor:"file" type:"path"`
+
+	// Flags.
+	OutputFile string `help:"The file to write the generated XR YAML to. Defaults to stdout."                                                                         placeholder:"PATH" predictor:"file" short:"o" type:"path"`
+	Name       string `help:"The name to use for the XR. If empty, defaults to the Claim's name (direct mode) or the Claim's name with a random suffix (non-direct)." placeholder:"NAME" type:"string"`
+	Kind       string `help:"The kind to use for the XR. Defaults to 'X' prepended to the Claim's kind (for example, Infra -> XInfra)."                               placeholder:"KIND" type:"string"`
+	Direct     bool   `help:"Create a direct XR without Claim references and suffix."                                                                                 name:"direct"      negatable:""`
+	GenUID     bool   `help:"Set a fresh random metadata.uid on the generated XR."                                                                                    name:"gen-uid"`
+
+	fs afero.Fs
+}
+
+func (c *generateCmd) Help() string {
+	return generateHelp
+}
+
+// AfterApply implements kong.AfterApply.
+func (c *generateCmd) AfterApply() error {
+	c.fs = afero.NewOsFs()
+	return nil
+}
+
+// Run runs the generate command.
+func (c *generateCmd) Run(k *kong.Context) error {
+	claimData, err := commonIO.Read(c.fs, c.InputFile)
+	if err != nil {
+		return err
+	}
+
+	claim := &unstructured.Unstructured{}
+	if err := yaml.Unmarshal(claimData, claim); err != nil {
+		return errors.Wrap(err, "cannot unmarshal Claim")
+	}
+
+	// Convert to XR
+	xr, err := ConvertClaimToXR(claim, Options{
+		Name:        c.Name,
+		Kind:        c.Kind,
+		Direct:      c.Direct,
+		GenerateUID: c.GenUID,
+	})
+	if err != nil {
+		return errors.Wrap(err, "cannot convert Claim to XR")
+	}
+
+	b, err := yaml.Marshal(xr)
+	if err != nil {
+		return errors.Wrap(err, "cannot marshal XR")
+	}
+
+	data := append([]byte("---\n"), b...)
+
+	if c.OutputFile != "" {
+		if err := afero.WriteFile(c.fs, c.OutputFile, data, 0o644); err != nil {
+			return errors.Wrapf(err, "cannot write output file %q", c.OutputFile)
+		}
+
+		return nil
+	}
+
+	if _, err := k.Stdout.Write(data); err != nil {
+		return errors.Wrap(err, "cannot write output")
+	}
+
+	return nil
+}
+
+const (
+	labelClaimName      = "crossplane.io/claim-name"
+	labelClaimNamespace = "crossplane.io/claim-namespace"
+	labelComposite      = "crossplane.io/composite"
+)
+
+// Options configures ConvertClaimToXR.
+type Options struct {
+	// Name is the XR name. Empty falls back to:
+	//   - claim.Name when Direct is true
+	//   - claim.Name with a random suffix when Direct is false
+	// A non-empty Name overrides both fallbacks.
+	Name string
+
+	// Kind is the XR kind. Empty defaults to "X" + claim.Kind.
+	Kind string
+
+	// Direct controls XR linkage to the claim:
+	//   - true:  no spec.claimRef; no claim-name/claim-namespace labels
+	//   - false: spec.claimRef is set; claim-name/claim-namespace labels added
+	Direct bool
+
+	// GenerateUID, when true, sets metadata.uid to a fresh random UUID.
+	GenerateUID bool
+}
+
+// ConvertClaimToXR converts a Crossplane Claim to a Composite Resource (XR).
+func ConvertClaimToXR(claim *unstructured.Unstructured, opts Options) (*composite.Unstructured, error) {
+	if claim == nil {
+		return nil, errors.New("input is nil")
+	}
+
+	if claim.Object == nil {
+		return nil, errors.New("invalid Claim YAML: parsed object is empty")
+	}
+
+	// Get Claim's properties
+	claimName := claim.GetName()
+
+	claimKind := claim.GetKind()
+	if claimKind == "" {
+		return nil, errors.New("no kind section in Claim")
+	}
+
+	apiVersion := claim.GetAPIVersion()
+	if apiVersion == "" {
+		return nil, errors.New("no apiVersion in Claim")
+	}
+
+	if _, err := schema.ParseGroupVersion(apiVersion); err != nil {
+		return nil, errors.Wrap(err, "cannot parse Claim APIVersion")
+	}
+
+	annotations := claim.GetAnnotations()
+
+	labels := claim.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	claimSpec, ok := claim.Object["spec"].(map[string]any)
+	if !ok || claimSpec == nil {
+		return nil, errors.New("no spec section in Claim")
+	}
+
+	// Create a new XR and pave it for manipulation
+	xr := composite.New()
+
+	xrPaved, err := fieldpath.PaveObject(xr)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot pave object")
+	}
+
+	if err := xrPaved.SetString("apiVersion", apiVersion); err != nil {
+		return nil, errors.Wrap(err, "cannot set apiVersion")
+	}
+
+	// Set XR kind - either from opts or by prepending X to Claim's kind
+	kind := opts.Kind
+	if kind == "" {
+		kind = "X" + claimKind
+	}
+
+	if err := xrPaved.SetString("kind", kind); err != nil {
+		return nil, errors.Wrap(err, "cannot set kind")
+	}
+
+	if len(annotations) > 0 {
+		if err := xrPaved.SetValue("metadata.annotations", annotations); err != nil {
+			return nil, errors.Wrap(err, "cannot set annotations")
+		}
+	}
+
+	if err := xrPaved.SetValue("spec", claimSpec); err != nil {
+		return nil, errors.Wrap(err, "cannot set spec")
+	}
+
+	xrName := claimName
+
+	if !opts.Direct {
+		xrName = names.SimpleNameGenerator.GenerateName(claimName + "-")
+		labels[labelClaimName] = claim.GetName()
+
+		labels[labelClaimNamespace] = claim.GetNamespace()
+		if err := xrPaved.SetValue("spec.claimRef", map[string]any{
+			"apiVersion": apiVersion,
+			"kind":       claimKind,
+			"name":       claimName,
+			"namespace":  claim.GetNamespace(),
+		}); err != nil {
+			return nil, errors.Wrap(err, "cannot set claimRef")
+		}
+	}
+
+	// Explicit Name overrides both Direct's claim-name default and the generated suffix.
+	if opts.Name != "" {
+		xrName = opts.Name
+	}
+
+	if err := xrPaved.SetString("metadata.name", xrName); err != nil {
+		return nil, errors.Wrap(err, "cannot set name")
+	}
+
+	if len(labels) > 0 {
+		delete(labels, labelComposite)
+
+		if err := xrPaved.SetValue("metadata.labels", labels); err != nil {
+			return nil, errors.Wrap(err, "cannot set labels")
+		}
+	}
+
+	if opts.GenerateUID {
+		xr.SetUID(uuid.NewUUID())
+	}
+
+	return xr, nil
+}

--- a/cmd/crossplane/xr/generate_test.go
+++ b/cmd/crossplane/xr/generate_test.go
@@ -1,0 +1,682 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package xr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+)
+
+// Helper functions for common Claim modifications
+
+// generateTestClaim creates a test Claim object with a default structure.
+// It accepts optional modifier functions that can customize the Claim's content.
+func generateTestClaim(opts ...func(*unstructured.Unstructured)) *unstructured.Unstructured {
+	claim := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "example.org/v1alpha1",
+			"kind":       "TestApp",
+			"metadata": map[string]any{
+				"name":      "test-app",
+				"namespace": "myclaims",
+			},
+			"spec": map[string]any{},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(claim)
+	}
+
+	return claim
+}
+
+// Shared test data variables.
+var (
+	testClaim = generateTestClaim()
+
+	testClaimWithLabels = generateTestClaim(
+		withLabels(map[string]any{
+			"existing-label": "value",
+		}),
+	)
+
+	testClaimWithComplexSpec = generateTestClaim(
+		withComplexSpec(),
+	)
+
+	testClaimWithAnnotations = generateTestClaim(
+		withAnnotations(map[string]any{
+			"test-annotation": "value",
+		}),
+	)
+
+	testClaimInvalidAPIVersion = generateTestClaim(
+		withAPIVersion("example.org/v1/v2"),
+	)
+
+	testClaimWithMultiFieldSpec = generateTestClaim(
+		withMultiFieldSpec(),
+	)
+)
+
+// withoutMandatoryField returns an option function that removes a mandatory field from the Claim.
+// This is used to test error handling when processing Claims without a mandatory field.
+func withoutMandatoryField(field string) func(*unstructured.Unstructured) {
+	return func(u *unstructured.Unstructured) {
+		delete(u.Object, field)
+	}
+}
+
+// withMultiFieldSpec returns an option function that adds multiple fields of different types
+// to the Claim's spec. This is used to test proper handling of different field types.
+func withMultiFieldSpec() func(*unstructured.Unstructured) {
+	return func(u *unstructured.Unstructured) {
+		u.Object["spec"] = map[string]any{
+			"stringField": "value1",
+			"numberField": float64(42), // YAML unmarshals integers as float64
+			"boolField":   true,
+			"objectField": map[string]any{
+				"nested": "value",
+			},
+			"arrayField": []any{
+				"item1",
+				"item2",
+			},
+		}
+	}
+}
+
+// withLabels returns an option function that adds the specified labels to the Claim's metadata.
+// This is used to test proper handling and merging of existing labels with Crossplane-specific labels.
+func withLabels(labels map[string]any) func(*unstructured.Unstructured) {
+	return func(u *unstructured.Unstructured) {
+		meta := u.Object["metadata"].(map[string]any)
+		meta["labels"] = labels
+	}
+}
+
+// withAnnotations returns an option function that adds the specified annotations to the Claim's metadata.
+// This is used to test proper copying of annotations from Claim to XR.
+func withAnnotations(annotations map[string]any) func(*unstructured.Unstructured) {
+	return func(u *unstructured.Unstructured) {
+		meta := u.Object["metadata"].(map[string]any)
+		meta["annotations"] = annotations
+	}
+}
+
+// withAPIVersion returns an option function that sets the apiVersion field of the Claim.
+// This is used to test handling of different API versions.
+func withAPIVersion(apiVersion string) func(*unstructured.Unstructured) {
+	return func(u *unstructured.Unstructured) {
+		u.Object["apiVersion"] = apiVersion
+	}
+}
+
+// withComplexSpec returns an option function that adds a complex nested spec to the Claim.
+func withComplexSpec() func(*unstructured.Unstructured) {
+	return func(u *unstructured.Unstructured) {
+		u.Object["spec"] = map[string]any{
+			"intField":    float64(42), // YAML unmarshals integers as float64
+			"floatField":  float64(3.14159),
+			"stringField": "hello",
+			"boolField":   true,
+			"objectField": map[string]any{
+				"nestedInt":   float64(123), // YAML unmarshals integers as float64
+				"nestedFloat": float64(456.789),
+				"nestedObject": map[string]any{
+					"deeplyNested": "value",
+				},
+			},
+			"arrayField": []any{
+				float64(1234), // YAML unmarshals integers as float64
+				"string in array",
+				map[string]any{
+					"objectInArray": true,
+				},
+			},
+		}
+	}
+}
+
+// generateExpectedXR creates an expected XR object based on a Claim, applying standard transformations.
+func generateExpectedXR(claim *unstructured.Unstructured, kind string, direct bool, opts ...func(*unstructured.Unstructured)) *unstructured.Unstructured {
+	name := claim.GetName()
+	if !direct {
+		name += "-abcde"
+	}
+
+	xrKind := kind
+	if xrKind == "" {
+		xrKind = "X" + claim.GetKind()
+	}
+
+	// Create base XR
+	xr := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "example.org/v1alpha1",
+			"kind":       xrKind,
+			"metadata": map[string]any{
+				"name": name,
+			},
+			"spec": map[string]any{},
+		},
+	}
+
+	if !direct {
+		// Add Crossplane labels
+		metadata := xr.Object["metadata"].(map[string]any)
+		metadata["labels"] = map[string]any{
+			"crossplane.io/claim-name":      claim.GetName(),
+			"crossplane.io/claim-namespace": claim.GetNamespace(),
+		}
+
+		// Add claimRef
+		spec := xr.Object["spec"].(map[string]any)
+		spec["claimRef"] = map[string]any{
+			"apiVersion": claim.GetAPIVersion(),
+			"kind":       claim.GetKind(),
+			"name":       claim.GetName(),
+			"namespace":  claim.GetNamespace(),
+		}
+	}
+
+	// Apply any additional options
+	for _, opt := range opts {
+		opt(xr)
+	}
+
+	return xr
+}
+
+func TestConvertClaimToXR(t *testing.T) {
+	type args struct {
+		claim *unstructured.Unstructured
+		opts  Options
+	}
+
+	type want struct {
+		xr        *unstructured.Unstructured
+		err       error
+		nameLen   int  // Length of the generated name, for validation of suffix length
+		expectUID bool // Whether the result should have a non-empty metadata.uid
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"NilClaim": {
+			reason: "Should return error when Claim is nil",
+			args: args{
+				claim: nil,
+				opts:  Options{},
+			},
+			want: want{
+				xr:  nil,
+				err: errors.New("input is nil"),
+			},
+		},
+		"EmptyObject": {
+			reason: "Should return error when Claim object is nil",
+			args: args{
+				claim: &unstructured.Unstructured{},
+				opts:  Options{},
+			},
+			want: want{
+				xr:  nil,
+				err: errors.New("invalid Claim YAML: parsed object is empty"),
+			},
+		},
+		"Direct": {
+			reason: "Should keep original name when Direct is true",
+			args: args{
+				claim: testClaim,
+				opts:  Options{Direct: true},
+			},
+			want: want{
+				xr:      generateExpectedXR(testClaim, "", true),
+				err:     nil,
+				nameLen: len("test-app"),
+			},
+		},
+		"NotDirect": {
+			reason: "Should append random suffix when Direct is false",
+			args: args{
+				claim: testClaim,
+				opts:  Options{},
+			},
+			want: want{
+				xr:      generateExpectedXR(testClaim, "", false),
+				err:     nil,
+				nameLen: len("test-app-") + 5, // name length should be original name + hyphen + 5 char suffix
+			},
+		},
+		"ErrNoAPIVersion": {
+			reason: "Should return error when Claim has no apiVersion",
+			args: args{
+				claim: generateTestClaim(withoutMandatoryField("apiVersion")),
+				opts:  Options{},
+			},
+			want: want{
+				xr:  nil,
+				err: errors.New("no apiVersion in Claim"),
+			},
+		},
+		"InvalidAPIVersion": {
+			reason: "Should return error for invalid API version",
+			args: args{
+				claim: testClaimInvalidAPIVersion,
+				opts:  Options{},
+			},
+			want: want{
+				xr:  nil,
+				err: errors.Wrap(errors.New("unexpected GroupVersion string: example.org/v1/v2"), "cannot parse Claim APIVersion"),
+			},
+		},
+		"ErrNoKind": {
+			reason: "Should return error when Claim has no kind",
+			args: args{
+				claim: generateTestClaim(withoutMandatoryField("kind")),
+				opts:  Options{},
+			},
+			want: want{
+				xr:  nil,
+				err: errors.New("no kind section in Claim"),
+			},
+		},
+		"ErrNoSpec": {
+			reason: "Should return error when Claim has no spec",
+			args: args{
+				claim: generateTestClaim(withoutMandatoryField("spec")),
+				opts:  Options{},
+			},
+			want: want{
+				xr:  nil,
+				err: errors.New("no spec section in Claim"),
+			},
+		},
+		"PreservesComplexSpec": {
+			reason: "Should preserve complex spec fields and their native types when converting from Claim to XR",
+			args: args{
+				claim: testClaimWithComplexSpec,
+				opts:  Options{Direct: true},
+			},
+			want: want{
+				err: nil,
+				xr: &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "example.org/v1alpha1",
+						"kind":       "XTestApp",
+						"metadata": map[string]any{
+							"name": "test-app",
+						},
+						"spec": map[string]any{
+							"intField":    int64(42), // Whole numbers become int64
+							"floatField":  float64(3.14159),
+							"stringField": "hello",
+							"boolField":   true,
+							"objectField": map[string]any{
+								"nestedInt":   int64(123), // Whole numbers become int64
+								"nestedFloat": float64(456.789),
+								"nestedObject": map[string]any{
+									"deeplyNested": "value",
+								},
+							},
+							"arrayField": []any{
+								int64(1234), // Whole numbers become int64
+								"string in array",
+								map[string]any{
+									"objectInArray": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"StandardLabelsWithoutExistingLabels": {
+			reason: "Should add standard Crossplane labels when no other labels exist",
+			args: args{
+				claim: testClaim,
+				opts:  Options{},
+			},
+			want: want{
+				err:     nil,
+				xr:      generateExpectedXR(testClaim, "", false),
+				nameLen: len("test-app-") + 5,
+			},
+		},
+		"LabelsHandling": {
+			reason: "Should properly merge existing labels with Crossplane labels",
+			args: args{
+				claim: generateTestClaim(
+					withLabels(map[string]any{
+						"existing-label": "value",
+						labelClaimName:   "old-value",
+					}),
+				),
+				opts: Options{},
+			},
+			want: want{
+				err: nil,
+				xr: &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "example.org/v1alpha1",
+						"kind":       "XTestApp",
+						"metadata": map[string]any{
+							"name": "test-app-abcde",
+							"labels": map[string]any{
+								"existing-label":    "value",
+								labelClaimName:      "test-app",
+								labelClaimNamespace: "myclaims",
+							},
+						},
+						"spec": map[string]any{
+							"claimRef": map[string]any{
+								"apiVersion": "example.org/v1alpha1",
+								"kind":       "TestApp",
+								"name":       "test-app",
+								"namespace":  "myclaims",
+							},
+						},
+					},
+				},
+			},
+		},
+		"WithAnnotations": {
+			reason: "Should properly copy annotations from Claim to XR",
+			args: args{
+				claim: testClaimWithAnnotations,
+				opts:  Options{Direct: true},
+			},
+			want: want{
+				err: nil,
+				xr: &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "example.org/v1alpha1",
+						"kind":       "XTestApp",
+						"metadata": map[string]any{
+							"name": "test-app",
+							"annotations": map[string]any{
+								"test-annotation": "value",
+							},
+						},
+						"spec": map[string]any{},
+					},
+				},
+			},
+		},
+		"NoNamespaceInXR": {
+			reason: "Should not include namespace in XR metadata as XRs are cluster-scoped",
+			args: args{
+				claim: testClaim,
+				opts:  Options{},
+			},
+			want: want{
+				err: nil,
+				xr:  generateExpectedXR(testClaim, "", false),
+			},
+		},
+		"CustomKindFlag": {
+			reason: "Should use provided kind instead of deriving from Claim kind",
+			args: args{
+				claim: testClaim,
+				opts:  Options{Kind: "CustomKind"},
+			},
+			want: want{
+				xr:  generateExpectedXR(testClaim, "CustomKind", false),
+				err: nil,
+			},
+		},
+		"DirectCustomKindFlag": {
+			reason: "Direct XR should use provided kind instead of deriving from Claim kind",
+			args: args{
+				claim: testClaim,
+				opts:  Options{Kind: "CustomKind", Direct: true},
+			},
+			want: want{
+				xr:  generateExpectedXR(testClaim, "CustomKind", true),
+				err: nil,
+			},
+		},
+		"DirectNoLabels": {
+			reason: "Direct XR should have no Crossplane labels",
+			args: args{
+				claim: testClaim,
+				opts:  Options{Direct: true},
+			},
+			want: want{
+				xr: &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "example.org/v1alpha1",
+						"kind":       "XTestApp",
+						"metadata": map[string]any{
+							"name": "test-app",
+						},
+						"spec": map[string]any{},
+					},
+				},
+				err:     nil,
+				nameLen: len("test-app"),
+			},
+		},
+		"DirectWithExistingLabels": {
+			reason: "Direct XR should keep existing labels but not add Crossplane labels",
+			args: args{
+				claim: testClaimWithLabels,
+				opts:  Options{Direct: true},
+			},
+			want: want{
+				xr: &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "example.org/v1alpha1",
+						"kind":       "XTestApp",
+						"metadata": map[string]any{
+							"name": "test-app",
+							"labels": map[string]any{
+								"existing-label": "value",
+							},
+						},
+						"spec": map[string]any{},
+					},
+				},
+				err:     nil,
+				nameLen: len("test-app"),
+			},
+		},
+		"LabelsShouldMatchGeneratedName": {
+			reason: "Labels should match the generated name in XR",
+			args: args{
+				claim: testClaim,
+				opts:  Options{},
+			},
+			want: want{
+				xr:      generateExpectedXR(testClaim, "", false),
+				err:     nil,
+				nameLen: len("test-app-") + 5, // name length should be original name + hyphen + 5 char suffix
+			},
+		},
+		"CopyAllSpecFields": {
+			reason: "Should copy all spec fields from Claim to XR, preserving types",
+			args: args{
+				claim: testClaimWithMultiFieldSpec,
+				opts:  Options{Direct: true},
+			},
+			want: want{
+				err: nil,
+				xr: &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "example.org/v1alpha1",
+						"kind":       "XTestApp",
+						"metadata": map[string]any{
+							"name": "test-app",
+						},
+						"spec": map[string]any{
+							"stringField": "value1",
+							"numberField": int64(42), // Whole numbers become int64
+							"boolField":   true,
+							"objectField": map[string]any{
+								"nested": "value",
+							},
+							"arrayField": []any{
+								"item1",
+								"item2",
+							},
+						},
+					},
+				},
+			},
+		},
+		"ExplicitNameOverridesDirectDefault": {
+			reason: "Explicit Name should override the Direct-mode claim-name default",
+			args: args{
+				claim: testClaim,
+				opts:  Options{Name: "my-xr", Direct: true},
+			},
+			want: want{
+				err:     nil,
+				nameLen: len("my-xr"),
+				xr: &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "example.org/v1alpha1",
+						"kind":       "XTestApp",
+						"metadata": map[string]any{
+							"name": "my-xr",
+						},
+						"spec": map[string]any{},
+					},
+				},
+			},
+		},
+		"ExplicitNameOverridesGeneratedSuffix": {
+			reason: "Explicit Name should override the non-Direct random-suffix name; claimRef and labels remain",
+			args: args{
+				claim: testClaim,
+				opts:  Options{Name: "my-xr"},
+			},
+			want: want{
+				err:     nil,
+				nameLen: len("my-xr"),
+				xr: &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "example.org/v1alpha1",
+						"kind":       "XTestApp",
+						"metadata": map[string]any{
+							"name": "my-xr",
+							"labels": map[string]any{
+								labelClaimName:      "test-app",
+								labelClaimNamespace: "myclaims",
+							},
+						},
+						"spec": map[string]any{
+							"claimRef": map[string]any{
+								"apiVersion": "example.org/v1alpha1",
+								"kind":       "TestApp",
+								"name":       "test-app",
+								"namespace":  "myclaims",
+							},
+						},
+					},
+				},
+			},
+		},
+		"GenerateUID": {
+			reason: "GenerateUID should set a non-empty metadata.uid",
+			args: args{
+				claim: testClaim,
+				opts:  Options{Direct: true, GenerateUID: true},
+			},
+			want: want{
+				err:       nil,
+				nameLen:   len("test-app"),
+				expectUID: true,
+				// xr left nil; UID is randomly generated so we validate via expectUID and ignore the rest.
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := ConvertClaimToXR(tc.args.claim, tc.args.opts)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nConvertClaimToXR(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+
+			// Use custom comparison to ignore generated name suffixes
+			opt := cmpopts.IgnoreMapEntries(func(k, v any) bool {
+				key, ok := k.(string)
+				if !ok {
+					return false
+				}
+				// Ignore generated name suffixes and composite label values
+				if key == "name" && v.(string) != "test-app" && v.(string) != "my-xr" {
+					return true
+				}
+
+				if key == "crossplane.io/composite" && strings.HasPrefix(v.(string), "test-app-") {
+					return true
+				}
+
+				// UID is random; compare separately via expectUID.
+				if key == "uid" {
+					return true
+				}
+
+				return false
+			})
+			if tc.want.xr != nil {
+				// got is *composite.Unstructured; compare against the want *unstructured.Unstructured by Object map.
+				if diff := cmp.Diff(tc.want.xr.Object, got.UnstructuredContent(), opt); diff != "" {
+					t.Errorf("\n%s\nConvertClaimToXR(...): -want, +got:\n%s", tc.reason, diff)
+				}
+			}
+
+			// Verify name length if specified in test case
+			if tc.want.nameLen > 0 && got != nil {
+				gotName, exists, err := unstructured.NestedString(got.Object, "metadata", "name")
+				if err != nil {
+					t.Errorf("\n%s\nError getting name: %v", tc.reason, err)
+				}
+
+				if !exists {
+					t.Errorf("\n%s\nName field not found in output", tc.reason)
+				}
+
+				if len(gotName) != tc.want.nameLen {
+					t.Errorf("\n%s\nName length mismatch: want %d, got %d", tc.reason, tc.want.nameLen, len(gotName))
+				}
+			}
+
+			// Verify UID was set when expected
+			if tc.want.expectUID {
+				if got == nil || got.GetUID() == "" {
+					t.Errorf("\n%s\nExpected non-empty metadata.uid, got empty", tc.reason)
+				}
+			}
+		})
+	}
+}

--- a/cmd/crossplane/xr/help/generate.md
+++ b/cmd/crossplane/xr/help/generate.md
@@ -1,0 +1,56 @@
+The `xr generate` command creates a Composite Resource (XR) from a Claim YAML.
+
+It reads the Claim from a file (or stdin), produces an XR (same spec, derived
+kind, optional Claim reference), and writes the result to stdout or to a file.
+
+## Examples
+
+Generate an XR from `claim.yaml` and print it to stdout (kind is `X` + Claim's
+kind):
+
+```shell
+crossplane xr generate claim.yaml
+```
+
+Generate an XR from `claim.yaml` and write it to `xr.yaml`:
+
+```shell
+crossplane xr generate claim.yaml -o xr.yaml
+```
+
+Generate an XR with an explicit name (overrides the default suffix or Claim
+name):
+
+```shell
+crossplane xr generate claim.yaml --name my-xr
+```
+
+Generate an XR with a specific kind:
+
+```shell
+crossplane xr generate claim.yaml --kind MyCompositeResource
+```
+
+Generate a directly linked XR (no Claim reference, no name suffix):
+
+```shell
+crossplane xr generate claim.yaml --direct
+```
+
+Generate an XR with a fresh random `metadata.uid`:
+
+```shell
+crossplane xr generate claim.yaml --gen-uid
+```
+
+Use in `crossplane render`:
+
+```shell
+crossplane render <(crossplane xr generate claim.yaml) composition.yaml functions.yaml
+```
+
+Read the Claim from stdin:
+
+```shell
+cat claim.yaml | crossplane xr generate -
+```

--- a/cmd/crossplane/xr/xr.go
+++ b/cmd/crossplane/xr/xr.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package xr contains commands for working with Crossplane Composite Resources (XRs).
+package xr
+
+// Cmd contains XR subcommands.
+type Cmd struct {
+	Generate generateCmd `cmd:"" help:"Generate a Composite Resource (XR) from a Claim."`
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Introduce a Claim to XR converter: `crossplane xr generate claim.yaml`. Similarly to other converter functions/tools, it takes a Claim either on stdin or as file argument and generates an equivalent XR YAML.

The parent `crossplane xr` is marked as maturity "alpha", which applies to the subtree as well.

This new tool can be used together with the render command as shown in the example below:

```bash
crossplane render <(crossplane xr generate claim.yaml) composition.yaml functions.yaml
```

The library function ConvertClaimToXR can be used by downstream tools (eg crossplane-diff) that rely on Claim to XR conversion.

The tool (and as a result the converter function, via the Options struct) is configurable and provides the following flags:
- `--direct`: omit spec.claimRef and the equivalent labels.
- `--name`: specify an explicit XR name, skipping either the random suffix in the non-direct mode or the Claim name fallback in direct mode.
- `--kind`: override the derived "X<Kind>" default.
- `--gen-uid`: populate metadata.uid with a fresh random UUID.

I didn't create new docs issue/PR, we can use https://github.com/crossplane/docs/issues/1088

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
