### PR TITLE
build: Use the shared crossplane cachix cache in nix.sh

### DIFF
--- a/nix.sh
+++ b/nix.sh
@@ -96,8 +96,8 @@ sandbox = true
 # Cachix is a binary cache service. Our GitHub Actions CI pushes there, so if CI
 # has recently built the commit you're on Nix will download stuff instead of
 # rebuilding it locally.
-extra-substituters = https://crossplane-cli.cachix.org
-extra-trusted-public-keys = crossplane-cli.cachix.org-1:NJluVUN9TX0rY/zAxHYaT19Y5ik4ELH4uFuxje+62d4=
+extra-substituters = https://crossplane.cachix.org
+extra-trusted-public-keys = crossplane.cachix.org-1:NJluVUN9TX0rY/zAxHYaT19Y5ik4ELH4uFuxje+62d4=
 "
 
 # Only allocate a TTY if stdout is a terminal. TTY mode corrupts binary


### PR DESCRIPTION
### Description of your changes

Our CI is already pushing to the org-wide cachix cache called `crossplane`. Update nix.sh to use this cache rather than the non-existent one called `crossplane-cli`.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
