### PR TITLE
Add the install.sh script and upload it to S3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+
+set -eu
+
+XP_CHANNEL=${XP_CHANNEL:-stable}
+XP_VERSION=${XP_VERSION:-current}
+
+os=$(uname -s)
+arch=$(uname -m)
+OS=${OS:-"${os}"}
+ARCH=${ARCH:-"${arch}"}
+OS_ARCH=""
+COMPRESSED=${COMPRESSED:-"False"}
+
+BIN=${BIN:-crossplane}
+
+# v2.3.0 was the first release from the crossplane/cli repository, whose
+# artifacts go to the cli.crossplane.io bucket and uses the binary name
+# "crossplane". Use the old releases.crossplane.io hostname and "crank" binary
+# for older releases.
+
+url_host="cli.crossplane.io"
+bundle_name="crossplane-cli.tar.gz"
+
+if [ "${XP_VERSION}" != "current" ]; then
+	_ver=$(echo "${XP_VERSION}" | sed 's/^v//' | sed 's/-.*//')
+	_major=$(echo "${_ver}" | cut -d. -f1)
+	_minor=$(echo "${_ver}" | cut -d. -f2)
+
+	if [ "${_major}" -lt 2 ] 2>/dev/null ||
+		{ [ "${_major}" -eq 2 ] 2>/dev/null && [ "${_minor}" -lt 3 ] 2>/dev/null; }; then
+
+		url_host="releases.crossplane.io"
+		bundle_name="crank.tar.gz"
+		BIN="crank"
+	fi
+fi
+
+unsupported_arch() {
+	os="$1"
+	arch="$2"
+	echo "Crossplane does not support $os / $arch at this time."
+	exit 1
+}
+
+case $OS in
+CYGWIN* | MINGW64* | Windows*)
+	if [ "$ARCH" = "x86_64" ]; then
+		OS_ARCH=windows_amd64
+		BIN="${BIN}.exe"
+	else
+		unsupported_arch "$OS" "$ARCH"
+	fi
+	;;
+Darwin)
+	case $ARCH in
+	x86_64 | amd64)
+		OS_ARCH=darwin_amd64
+		;;
+	arm64)
+		OS_ARCH=darwin_arm64
+		;;
+	*)
+		unsupported_arch "$OS" "$ARCH"
+		;;
+	esac
+	;;
+Linux)
+	case $ARCH in
+	x86_64 | amd64)
+		OS_ARCH=linux_amd64
+		;;
+	arm64 | aarch64)
+		OS_ARCH=linux_arm64
+		;;
+	*)
+		unsupported_arch "$OS" "$ARCH"
+		;;
+	esac
+	;;
+*)
+	unsupported_arch "$OS" "$ARCH"
+	;;
+esac
+
+_compr=$(echo "$COMPRESSED" | tr '[:upper:]' '[:lower:]')
+
+if [ "${_compr}" = "true" ]; then
+	url_dir="bundle"
+	url_file="${bundle_name}"
+	url_error="a compressed file for "
+else
+	url_dir="bin"
+	url_file="${BIN}"
+	url_error=""
+fi
+
+url="https://${url_host}/${XP_CHANNEL}/${XP_VERSION}/${url_dir}/${OS_ARCH}/${url_file}"
+
+if ! curl -sfL "${url}" -o "${url_file}"; then
+	echo "Failed to download Crossplane CLI. Please make sure ${url_error}version ${XP_VERSION} exists on channel ${XP_CHANNEL}."
+	exit 1
+fi
+
+if [ "${_compr}" = "true" ]; then
+	if ! tar xzf "${url_file}"; then
+		echo "Failed to unpack the Crossplane CLI compressed file."
+		exit 1
+	fi
+	rm "${BIN}.sha256" "${url_file}"
+fi
+if [ "${BIN}" != "crossplane" ]; then
+	if ! mv "${BIN}" crossplane; then
+		echo "Failed to rename the Crossplane CLI binary: \"${BIN}\"."
+		exit 1
+	fi
+fi
+
+chmod +x crossplane
+
+echo "crossplane CLI downloaded successfully! Run the following commands to finish installing it:"
+echo
+echo sudo mv crossplane /usr/local/bin
+echo crossplane --help
+echo
+echo "Visit https://crossplane.io to get started. 🚀"
+printf "Have a nice day! 👋\n"

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -187,6 +187,11 @@
             aws s3 sync --delete --only-show-errors "''${BUILD_PATH}" "''${CHANNEL_PATH}/current"
           fi
 
+          if [ "''${BRANCH}" == "main" ]; then
+            echo "Uploading install.sh..."
+            aws s3 cp --only-show-errors install.sh "s3://crossplane-cli-releases/"
+          fi
+
           echo "Done"
         '';
       }


### PR DESCRIPTION
### Description of your changes

Copy the install.sh script over from c/c, since its source of truth should probably be this repository. Update CI to push the script to our S3 bucket, so that if we update it in the future it automatically ends up there. Note that we upload install.sh from the `promote-artifacts` job only from the main branch.

Related docs change: https://github.com/crossplane/docs/pull/1099

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
