### PR TITLE
docs: Enclose the CLI version number in backticks

### DIFF
--- a/cmd/crossplane/docs-templates/command-reference.md.tmpl
+++ b/cmd/crossplane/docs-templates/command-reference.md.tmpl
@@ -11,7 +11,7 @@ description: "Command reference for the Crossplane CLI"
 <!-- vale Crossplane.Spelling = NO -->
 <!-- vale cli-docs = YES -->
 
-This documentation is for the `crossplane` CLI [[ .Version ]].
+This documentation is for the `crossplane` CLI `[[ .Version ]]`.
 
 [[ range .Commands ]]
 [[- range .NoVale ]]


### PR DESCRIPTION
### Description of your changes

At the top of our generated docs we have a line like:x

```markdown
This documentation is for the `crossplane` CLI v2.4.0-rc.0.10.gb96ad2d.
```

When using a development build (no version number) or a build with a proper version number (v2.3.1), this is fine. But when using a main branch build like the example above, the version number triggers some vale linter errors.

Enclose the version number in backticks (make it inline code) so that vale will ignore it. This will look fine in the rendered docs as well.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
