### PR TITLE
Fix Python schema generation for fields named int or bool

### DIFF
--- a/internal/schemas/generator/python.go
+++ b/internal/schemas/generator/python.go
@@ -47,7 +47,7 @@ const (
 	pythonPackageRoot          = "models"
 	pythonAdoptModelsStructure = "sorted"
 	pythonGeneratedFolder      = "models/workdir"
-	pythonImage                = "docker.io/koxudaxi/datamodel-code-generator:0.31.2"
+	pythonImage                = "docker.io/koxudaxi/datamodel-code-generator:0.59.0"
 )
 
 var importRE = regexp.MustCompile(`^(from\s+)(\.*)([^\s]+)(.*)`)
@@ -542,19 +542,6 @@ func processOpenAPIContent(doc *openapi3.T) *openapi3.T { //nolint:gocognit // s
 	return doc
 }
 
-func fixAliasedTypesInFile(fs afero.Fs, filePath string) error {
-	fileContent, err := afero.ReadFile(fs, filePath)
-	if err != nil {
-		return errors.Wrapf(err, "reading file %s", filePath)
-	}
-
-	content := string(fileContent)
-	content = strings.ReplaceAll(content, "bool_aliased", "bool")
-	content = strings.ReplaceAll(content, "int_aliased", "int")
-
-	return afero.WriteFile(fs, filePath, []byte(content), os.ModePerm)
-}
-
 func postTransformOpenAPI(fs afero.Fs, sourceDir, targetDir string) error {
 	createdInitDirs := make(map[string]bool)
 
@@ -587,8 +574,8 @@ func postTransformOpenAPI(fs afero.Fs, sourceDir, targetDir string) error {
 			return err
 		}
 
-		if err := postProcessFile(fs, destPath); err != nil {
-			return err
+		if err := adjustImportsInFile(fs, destPath); err != nil {
+			return errors.Wrapf(err, "adjusting imports")
 		}
 
 		return transformMetaImportsInFile(fs, destPath)
@@ -677,13 +664,6 @@ func copyFileWithInit(fs afero.Fs, srcPath, destPath, destDir string, created ma
 	}
 
 	return nil
-}
-
-func postProcessFile(fs afero.Fs, path string) error {
-	if err := adjustImportsInFile(fs, path); err != nil {
-		return errors.Wrapf(err, "adjusting imports")
-	}
-	return errors.Wrapf(fixAliasedTypesInFile(fs, path), "fixing aliased types")
 }
 
 func isMetaV1File(path string) bool {


### PR DESCRIPTION
### Description of your changes

Fixes #63

`crossplane project build` generates broken Python models when an XRD has a property literally named `int` or `bool` (for example when modelling DRA's `DeviceAttribute`, whose wire fields are `int`/`bool`/`string`/`version`). The generated models reference undefined type aliases `int_aliased` and `bool_aliased`, which makes them unimportable:

```
PydanticUserError: `ObjectMeta` is not fully defined; you should define `int_aliased`, then call `ObjectMeta.model_rebuild()`.
```

The undefined aliases are emitted by the pinned code generator image `docker.io/koxudaxi/datamodel-code-generator:0.31.2`. The CLI worked around this with `fixAliasedTypesInFile`, which text-replaced the broken aliases, but it only ran in the OpenAPI generation path — not the XRD/CRD path that `project build` uses — so XRD-derived models and the shared `meta/v1.py` kept the broken references.

The underlying code generator bug is fixed upstream in [koxudaxi/datamodel-code-generator#2968](https://github.com/koxudaxi/datamodel-code-generator/pull/2968), first released in `0.54.0`, which sanitizes builtin-conflicting field names by appending a trailing underscore and preserving the wire name via a Pydantic alias. A field named `int` now generates as `int_: int | None = Field(None, alias='int')`.

This PR bumps the pinned image to `0.59.0`, fixing the broken output at its source. With the fix in place `fixAliasedTypesInFile` no longer matches anything, so it is removed along with the `postProcessFile` wrapper, leaving both generation paths to call `adjustImportsInFile` directly.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~ The Python generator's image-backed output is not currently covered by automated tests; see the draft note above.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
