### PR TITLE
fix(render): do not overwrite function docker network if set, start crossplane-container in same network

### DIFF
--- a/cmd/crossplane/render/annotation.go
+++ b/cmd/crossplane/render/annotation.go
@@ -2,6 +2,7 @@ package render
 
 import "strings"
 
+// Annotations is a type used to store annotations.
 type Annotations map[string]string
 
 // NewAnnotationsFromStrings parses an array of strings in the format "key=value" into a map.

--- a/cmd/crossplane/render/annotation.go
+++ b/cmd/crossplane/render/annotation.go
@@ -1,0 +1,23 @@
+package render
+
+import "strings"
+
+type Annotations map[string]string
+
+// NewAnnotationsFromStrings parses an array of strings in the format "key=value" into a map.
+// Silently skips strings in incorrect format.
+func NewAnnotationsFromStrings(annotations []string) Annotations {
+	result := make(Annotations, 0)
+	for _, annotation := range annotations {
+		parts := strings.SplitN(annotation, "=", 2)
+
+		if len(parts) != 2 {
+			continue
+		}
+
+		key, value := parts[0], parts[1]
+		result[key] = value
+	}
+
+	return result
+}

--- a/cmd/crossplane/render/engine.go
+++ b/cmd/crossplane/render/engine.go
@@ -66,9 +66,7 @@ type EngineFlags struct {
 
 // NewEngineFromFlags creates an Engine from the flag configuration. If a binary
 // path is set, it returns a local engine. Otherwise it returns a Docker engine
-// using the resolved image reference. The network parameter sets the Docker
-// network the render container should join; it is derived from function
-// annotations (AnnotationKeyRuntimeDockerNetwork) by the caller.
+// using the resolved image reference.
 func NewEngineFromFlags(f *EngineFlags, log logging.Logger) Engine {
 	if f.CrossplaneBinary != "" {
 		return &localRenderEngine{BinaryPath: f.CrossplaneBinary}

--- a/cmd/crossplane/render/engine.go
+++ b/cmd/crossplane/render/engine.go
@@ -58,9 +58,9 @@ type Engine interface {
 // EngineFlags contains flags for configuring the render engine. It is embedded
 // by render command structs to provide shared engine configuration.
 type EngineFlags struct {
-	CrossplaneVersion       string `help:"Version of the Crossplane image to use for rendering. Defaults to the latest stable version." placeholder:"VERSION" xor:"crossplane-selector"`
-	CrossplaneImage         string `help:"Override the full Crossplane Docker image reference for rendering."                           placeholder:"IMAGE"   xor:"crossplane-selector"`
-	CrossplaneBinary        string `help:"Path to a local crossplane binary to use instead of Docker."                                  placeholder:"PATH"    type:"existingfile"       xor:"crossplane-selector,crossplane-docker"`
+	CrossplaneVersion       string `help:"Version of the Crossplane image to use for rendering. Defaults to the latest stable version." placeholder:"VERSION"   xor:"crossplane-selector"`
+	CrossplaneImage         string `help:"Override the full Crossplane Docker image reference for rendering."                           placeholder:"IMAGE"     xor:"crossplane-selector"`
+	CrossplaneBinary        string `help:"Path to a local crossplane binary to use instead of Docker."                                  placeholder:"PATH"      type:"existingfile"       xor:"crossplane-selector,crossplane-docker"`
 	CrossplaneDockerNetwork string `help:"The docker network to start the crossplane container in"                                      xor:"crossplane-docker"`
 }
 

--- a/cmd/crossplane/render/engine.go
+++ b/cmd/crossplane/render/engine.go
@@ -61,12 +61,13 @@ type EngineFlags struct {
 	CrossplaneVersion string `help:"Version of the Crossplane image to use for rendering. Defaults to the latest stable version." placeholder:"VERSION" xor:"crossplane-selector"`
 	CrossplaneImage   string `help:"Override the full Crossplane Docker image reference for rendering."                           placeholder:"IMAGE"   xor:"crossplane-selector"`
 	CrossplaneBinary  string `help:"Path to a local crossplane binary to use instead of Docker."                                  placeholder:"PATH"    type:"existingfile"       xor:"crossplane-selector"`
-	Network           string `help:"The network containers should connect to"`
 }
 
 // NewEngineFromFlags creates an Engine from the flag configuration. If a binary
 // path is set, it returns a local engine. Otherwise it returns a Docker engine
-// using the resolved image reference.
+// using the resolved image reference. The network parameter sets the Docker
+// network the render container should join; it is derived from function
+// annotations (AnnotationKeyRuntimeDockerNetwork) by the caller.
 func NewEngineFromFlags(f *EngineFlags, network string, log logging.Logger) Engine {
 	if f.CrossplaneBinary != "" {
 		return &localRenderEngine{BinaryPath: f.CrossplaneBinary}

--- a/cmd/crossplane/render/engine.go
+++ b/cmd/crossplane/render/engine.go
@@ -58,9 +58,10 @@ type Engine interface {
 // EngineFlags contains flags for configuring the render engine. It is embedded
 // by render command structs to provide shared engine configuration.
 type EngineFlags struct {
-	CrossplaneVersion string `help:"Version of the Crossplane image to use for rendering. Defaults to the latest stable version." placeholder:"VERSION" xor:"crossplane-selector"`
-	CrossplaneImage   string `help:"Override the full Crossplane Docker image reference for rendering."                           placeholder:"IMAGE"   xor:"crossplane-selector"`
-	CrossplaneBinary  string `help:"Path to a local crossplane binary to use instead of Docker."                                  placeholder:"PATH"    type:"existingfile"       xor:"crossplane-selector"`
+	CrossplaneVersion       string `help:"Version of the Crossplane image to use for rendering. Defaults to the latest stable version." placeholder:"VERSION" xor:"crossplane-selector"`
+	CrossplaneImage         string `help:"Override the full Crossplane Docker image reference for rendering."                           placeholder:"IMAGE"   xor:"crossplane-selector"`
+	CrossplaneBinary        string `help:"Path to a local crossplane binary to use instead of Docker."                                  placeholder:"PATH"    type:"existingfile"       xor:"crossplane-selector,crossplane-docker"`
+	CrossplaneDockerNetwork string `help:"The docker network to start the crossplane container in"                                      xor:"crossplane-docker"`
 }
 
 // NewEngineFromFlags creates an Engine from the flag configuration. If a binary
@@ -68,12 +69,12 @@ type EngineFlags struct {
 // using the resolved image reference. The network parameter sets the Docker
 // network the render container should join; it is derived from function
 // annotations (AnnotationKeyRuntimeDockerNetwork) by the caller.
-func NewEngineFromFlags(f *EngineFlags, network string, log logging.Logger) Engine {
+func NewEngineFromFlags(f *EngineFlags, log logging.Logger) Engine {
 	if f.CrossplaneBinary != "" {
 		return &localRenderEngine{BinaryPath: f.CrossplaneBinary}
 	}
 
-	return &dockerRenderEngine{image: crossplaneImageFromFlags(f), network: network, log: log}
+	return &dockerRenderEngine{image: crossplaneImageFromFlags(f), network: f.CrossplaneDockerNetwork, log: log}
 }
 
 func crossplaneImageFromFlags(f *EngineFlags) string {

--- a/cmd/crossplane/render/engine.go
+++ b/cmd/crossplane/render/engine.go
@@ -61,17 +61,18 @@ type EngineFlags struct {
 	CrossplaneVersion string `help:"Version of the Crossplane image to use for rendering. Defaults to the latest stable version." placeholder:"VERSION" xor:"crossplane-selector"`
 	CrossplaneImage   string `help:"Override the full Crossplane Docker image reference for rendering."                           placeholder:"IMAGE"   xor:"crossplane-selector"`
 	CrossplaneBinary  string `help:"Path to a local crossplane binary to use instead of Docker."                                  placeholder:"PATH"    type:"existingfile"       xor:"crossplane-selector"`
+	Network           string `help:"The network containers should connect to"`
 }
 
 // NewEngineFromFlags creates an Engine from the flag configuration. If a binary
 // path is set, it returns a local engine. Otherwise it returns a Docker engine
 // using the resolved image reference.
-func NewEngineFromFlags(f *EngineFlags, log logging.Logger) Engine {
+func NewEngineFromFlags(f *EngineFlags, network string, log logging.Logger) Engine {
 	if f.CrossplaneBinary != "" {
 		return &localRenderEngine{BinaryPath: f.CrossplaneBinary}
 	}
 
-	return &dockerRenderEngine{image: crossplaneImageFromFlags(f), log: log}
+	return &dockerRenderEngine{image: crossplaneImageFromFlags(f), network: network, log: log}
 }
 
 func crossplaneImageFromFlags(f *EngineFlags) string {

--- a/cmd/crossplane/render/engine_docker.go
+++ b/cmd/crossplane/render/engine_docker.go
@@ -93,13 +93,17 @@ func (e *dockerRenderEngine) Setup(ctx context.Context, fns []pkgv1.Function) (f
 		e.network = networkName
 
 		injectNetworkAnnotation(fns, networkName)
+
+		cleanup := func() { //nolint:contextcheck // Detached context for cleanup.
+			_ = removeRenderNetwork(context.Background(), networkID)
+		}
+
+		return cleanup, nil
 	}
 
-	cleanup := func() { //nolint:contextcheck // Detached context for cleanup.
-		_ = removeRenderNetwork(context.Background(), networkID)
-	}
-
-	return cleanup, nil
+	// e.network was pre-configured by the caller (e.g. from a function
+	// annotation). We don't own the network, so there is nothing to clean up.
+	return func() {}, nil
 }
 
 // Render marshals the request, runs it through a Docker container, and returns

--- a/cmd/crossplane/render/engine_docker.go
+++ b/cmd/crossplane/render/engine_docker.go
@@ -84,26 +84,25 @@ func (e *dockerRenderEngine) CheckContextSupport() error {
 func (e *dockerRenderEngine) Setup(ctx context.Context, fns []pkgv1.Function) (func(), error) {
 	var networkID, networkName string
 
-	if e.network == "" {
-		var err error
-		networkID, networkName, err = createRenderNetwork(ctx)
-		if err != nil {
-			return func() {}, errors.Wrap(err, "cannot create Docker network for rendering")
-		}
-		e.network = networkName
-
-		injectNetworkAnnotation(fns, networkName)
-
-		cleanup := func() { //nolint:contextcheck // Detached context for cleanup.
-			_ = removeRenderNetwork(context.Background(), networkID)
-		}
-
-		return cleanup, nil
+	if e.network != "" {
+		// e.network was pre-configured, we don't own the network, so there is nothing to clean up.
+		return func() {}, nil
 	}
 
-	// e.network was pre-configured by the caller (e.g. from a function
-	// annotation). We don't own the network, so there is nothing to clean up.
-	return func() {}, nil
+	var err error
+	networkID, networkName, err = createRenderNetwork(ctx)
+	if err != nil {
+		return func() {}, errors.Wrap(err, "cannot create Docker network for rendering")
+	}
+	e.network = networkName
+
+	injectNetworkAnnotation(fns, networkName)
+
+	cleanup := func() { //nolint:contextcheck // Detached context for cleanup.
+		_ = removeRenderNetwork(context.Background(), networkID)
+	}
+
+	return cleanup, nil
 }
 
 // Render marshals the request, runs it through a Docker container, and returns

--- a/cmd/crossplane/render/engine_docker.go
+++ b/cmd/crossplane/render/engine_docker.go
@@ -83,13 +83,18 @@ func (e *dockerRenderEngine) CheckContextSupport() error {
 // containers also join it. The returned cleanup function removes the
 // network.
 func (e *dockerRenderEngine) Setup(ctx context.Context, fns []pkgv1.Function) (func(), error) {
-	networkID, networkName, err := createRenderNetwork(ctx)
-	if err != nil {
-		return func() {}, errors.Wrap(err, "cannot create Docker network for rendering")
-	}
+	var networkID, networkName string
 
-	e.network = networkName
-	injectNetworkAnnotation(fns, networkName)
+	if e.network == "" {
+		var err error
+		networkID, networkName, err = createRenderNetwork(ctx)
+		if err != nil {
+			return func() {}, errors.Wrap(err, "cannot create Docker network for rendering")
+		}
+		e.network = networkName
+
+		injectNetworkAnnotation(fns, networkName)
+	}
 
 	cleanup := func() { //nolint:contextcheck // Detached context for cleanup.
 		_ = removeRenderNetwork(context.Background(), networkID)

--- a/cmd/crossplane/render/engine_docker.go
+++ b/cmd/crossplane/render/engine_docker.go
@@ -53,8 +53,7 @@ func (realContainerRunner) Run(ctx context.Context, img string, opts ...docker.R
 type dockerRenderEngine struct {
 	// image is the Crossplane Docker image reference.
 	image string
-	// network is the Docker network to connect the container to. When set,
-	// the container joins this network so it can reach function containers.
+	// network is the Docker network to connect the container to.
 	network string
 
 	log logging.Logger

--- a/cmd/crossplane/render/network.go
+++ b/cmd/crossplane/render/network.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 	"github.com/docker/docker/api/types/network"
 	"k8s.io/apimachinery/pkg/util/rand"
 
@@ -27,6 +28,22 @@ import (
 
 	"github.com/crossplane/cli/v2/internal/docker"
 )
+
+// SetDefaultCrossplaneDockerNetwork defaults the Crossplane render engine's
+// Docker network to the first function runtime Docker network annotation.
+// If network is already set, return with no changes
+func (f *EngineFlags) SetDefaultCrossplaneDockerNetwork(fns []pkgv1.Function) {
+	if f.CrossplaneDockerNetwork != "" {
+		return
+	}
+
+	for _, fn := range fns {
+		if value, ok := fn.Annotations[AnnotationKeyRuntimeDockerNetwork]; ok {
+			f.CrossplaneDockerNetwork = value
+			return
+		}
+	}
+}
 
 // createRenderNetwork creates a temporary Docker bridge network for render.
 // Function containers and the Crossplane render container join this network so

--- a/cmd/crossplane/render/network.go
+++ b/cmd/crossplane/render/network.go
@@ -39,7 +39,7 @@ func (f *EngineFlags) SetDefaultCrossplaneDockerNetwork(fns []pkgv1.Function) {
 	}
 
 	for _, fn := range fns {
-		if value, ok := fn.Annotations[AnnotationKeyRuntimeDockerNetwork]; ok {
+		if value, ok := fn.Annotations[AnnotationKeyRuntimeDockerNetwork]; ok && value != "" {
 			f.CrossplaneDockerNetwork = value
 			return
 		}

--- a/cmd/crossplane/render/network.go
+++ b/cmd/crossplane/render/network.go
@@ -31,7 +31,7 @@ import (
 
 // SetDefaultCrossplaneDockerNetwork defaults the Crossplane render engine's
 // Docker network to the first function runtime Docker network annotation.
-// If network is already set, return with no changes
+// If network is already set, return with no changes.
 func (f *EngineFlags) SetDefaultCrossplaneDockerNetwork(fns []pkgv1.Function) {
 	if f.CrossplaneDockerNetwork != "" {
 		return

--- a/cmd/crossplane/render/network.go
+++ b/cmd/crossplane/render/network.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"fmt"
 
-	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 	"github.com/docker/docker/api/types/network"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+
+	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
 
 	"github.com/crossplane/cli/v2/internal/docker"
 )

--- a/cmd/crossplane/render/network_test.go
+++ b/cmd/crossplane/render/network_test.go
@@ -1,0 +1,76 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+)
+
+func TestSetDefaultCrossplaneDockerNetwork(t *testing.T) {
+	type args struct {
+		flags     EngineFlags
+		functions []pkgv1.Function
+	}
+	type want struct {
+		flags EngineFlags
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ExplicitNetworkIsPreserved": {
+			reason: "An explicit --crossplane-docker-network value should not be overwritten by function annotations.",
+			args: args{
+				flags: EngineFlags{CrossplaneDockerNetwork: "explicit-network"},
+				functions: []pkgv1.Function{
+					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: "function-network"}),
+				},
+			},
+			want: want{
+				flags: EngineFlags{CrossplaneDockerNetwork: "explicit-network"},
+			},
+		},
+		"FirstFunctionAnnotationIsUsed": {
+			reason: "When no explicit network is set, the render engine should join the first function runtime Docker network.",
+			args: args{
+				functions: []pkgv1.Function{
+					functionWithAnnotations(map[string]string{"example.org/other": "ignored"}),
+					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: "first-network"}),
+					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: "second-network"}),
+				},
+			},
+			want: want{
+				flags: EngineFlags{CrossplaneDockerNetwork: "first-network"},
+			},
+		},
+		"NoNetwork": {
+			reason: "The flags should remain unchanged when no function has a runtime Docker network annotation.",
+			args: args{
+				functions: []pkgv1.Function{
+					functionWithAnnotations(nil),
+					functionWithAnnotations(map[string]string{"example.org/other": "ignored"}),
+				},
+			},
+			want: want{},
+		},
+		"NoFunctions": {
+			reason: "Rendering with no functions should not create a Docker network.",
+			want:   want{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Log(tc.reason)
+
+			tc.args.flags.SetDefaultCrossplaneDockerNetwork(tc.args.functions)
+			if diff := cmp.Diff(tc.want.flags, tc.args.flags); diff != "" {
+				t.Errorf("SetDefaultCrossplaneDockerNetwork(...), -want, +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/crossplane/render/network_test.go
+++ b/cmd/crossplane/render/network_test.go
@@ -57,8 +57,8 @@ func TestSetDefaultCrossplaneDockerNetwork(t *testing.T) {
 			},
 			want: want{},
 		},
-		"NoFunctions": {
-			reason: "Rendering with no functions should not create a Docker network.",
+		"NoFunctionsPreservesDefaultBehavior": {
+			reason: "No functions should leave CrossplaneDockerNetwork unset so engine setup can use its default temporary network behavior.",
 			want:   want{},
 		},
 	}

--- a/cmd/crossplane/render/op/cmd.go
+++ b/cmd/crossplane/render/op/cmd.go
@@ -180,7 +180,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		if len(c.FunctionAnnotations) > 0 {
 			annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
 			if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.EngineFlags.CrossplaneDockerNetwork = value
+				c.CrossplaneDockerNetwork = value
 			}
 		}
 	}

--- a/cmd/crossplane/render/op/cmd.go
+++ b/cmd/crossplane/render/op/cmd.go
@@ -167,23 +167,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		}
 	}
 
-	if c.CrossplaneDockerNetwork == "" {
-		// Default to the first docker-network annotation in the provided functions
-		for _, fn := range fns {
-			if value, ok := fn.Annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.CrossplaneDockerNetwork = value
-				break
-			}
-		}
-
-		// Overwrite with docker-network annotation from function-annotations cli flag if set
-		if len(c.FunctionAnnotations) > 0 {
-			annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
-			if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.CrossplaneDockerNetwork = value
-			}
-		}
-	}
+	c.SetDefaultCrossplaneDockerNetwork(fns)
 
 	engine := c.newEngine(&c.EngineFlags, log)
 

--- a/cmd/crossplane/render/op/cmd.go
+++ b/cmd/crossplane/render/op/cmd.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -169,16 +168,9 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 	}
 
 	var network string
-	for _, annotation := range c.FunctionAnnotations {
-		parts := strings.SplitN(annotation, "=", 2)
-		if len(parts) != 2 {
-			return errors.Errorf("invalid function annotation format %q, expected key=value", annotation)
-		}
-		key, value := parts[0], parts[1]
-		if key == render.AnnotationKeyRuntimeDockerNetwork {
-			network = value
-			break
-		}
+	annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
+	if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
+		network = value
 	}
 
 	engine := c.newEngine(&c.EngineFlags, network, log)

--- a/cmd/crossplane/render/op/cmd.go
+++ b/cmd/crossplane/render/op/cmd.go
@@ -171,7 +171,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		// Default to the first docker-network annotation in the provided functions
 		for _, fn := range fns {
 			if value, ok := fn.Annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.CrossplaneDockerNetwork = value
+				c.EngineFlags.CrossplaneDockerNetwork = value
 				break
 			}
 		}
@@ -180,7 +180,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		if len(c.FunctionAnnotations) > 0 {
 			annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
 			if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.CrossplaneDockerNetwork = value
+				c.EngineFlags.CrossplaneDockerNetwork = value
 			}
 		}
 	}

--- a/cmd/crossplane/render/op/cmd.go
+++ b/cmd/crossplane/render/op/cmd.go
@@ -84,7 +84,7 @@ type Cmd struct {
 	fs afero.Fs
 
 	// newEngine constructs the render Engine.
-	newEngine func(*render.EngineFlags, string, logging.Logger) render.Engine
+	newEngine func(*render.EngineFlags, logging.Logger) render.Engine
 }
 
 // Help prints out the help for the alpha render op command.
@@ -167,13 +167,25 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		}
 	}
 
-	var network string
-	annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
-	if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-		network = value
+	if c.EngineFlags.CrossplaneDockerNetwork == "" {
+		// Default to the first docker-network annotation in the provided functions
+		for _, fn := range fns {
+			if value, ok := fn.Annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
+				c.CrossplaneDockerNetwork = value
+				break
+			}
+		}
+
+		// Overwrite with docker-network annotation from function-annotations cli flag if set
+		if len(c.FunctionAnnotations) > 0 {
+			annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
+			if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
+				c.EngineFlags.CrossplaneDockerNetwork = value
+			}
+		}
 	}
 
-	engine := c.newEngine(&c.EngineFlags, network, log)
+	engine := c.newEngine(&c.EngineFlags, log)
 
 	seedCtx := len(c.ContextValues) > 0 || len(c.ContextFiles) > 0
 	captureCtx := c.IncludeContext
@@ -404,6 +416,5 @@ func (c *Cmd) loadFunctions(ctx context.Context, log logging.Logger, sp terminal
 	}); err != nil {
 		return nil, errors.Wrap(err, "cannot build embedded functions")
 	}
-
 	return fns, nil
 }

--- a/cmd/crossplane/render/op/cmd.go
+++ b/cmd/crossplane/render/op/cmd.go
@@ -167,11 +167,11 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		}
 	}
 
-	if c.EngineFlags.CrossplaneDockerNetwork == "" {
+	if c.CrossplaneDockerNetwork == "" {
 		// Default to the first docker-network annotation in the provided functions
 		for _, fn := range fns {
 			if value, ok := fn.Annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.EngineFlags.CrossplaneDockerNetwork = value
+				c.CrossplaneDockerNetwork = value
 				break
 			}
 		}
@@ -180,7 +180,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		if len(c.FunctionAnnotations) > 0 {
 			annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
 			if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.EngineFlags.CrossplaneDockerNetwork = value
+				c.CrossplaneDockerNetwork = value
 			}
 		}
 	}

--- a/cmd/crossplane/render/op/cmd.go
+++ b/cmd/crossplane/render/op/cmd.go
@@ -416,5 +416,6 @@ func (c *Cmd) loadFunctions(ctx context.Context, log logging.Logger, sp terminal
 	}); err != nil {
 		return nil, errors.Wrap(err, "cannot build embedded functions")
 	}
+
 	return fns, nil
 }

--- a/cmd/crossplane/render/op/cmd.go
+++ b/cmd/crossplane/render/op/cmd.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -84,7 +85,7 @@ type Cmd struct {
 	fs afero.Fs
 
 	// newEngine constructs the render Engine.
-	newEngine func(*render.EngineFlags, logging.Logger) render.Engine
+	newEngine func(*render.EngineFlags, string, logging.Logger) render.Engine
 }
 
 // Help prints out the help for the alpha render op command.
@@ -167,7 +168,20 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		}
 	}
 
-	engine := c.newEngine(&c.EngineFlags, log)
+	network := ""
+	for _, annotation := range c.FunctionAnnotations {
+		parts := strings.SplitN(annotation, "=", 2)
+		if len(parts) != 2 {
+			return errors.Errorf("invalid function annotation format %q, expected key=value", annotation)
+		}
+		key, value := parts[0], parts[1]
+		if key == render.AnnotationKeyRuntimeDockerNetwork {
+			network = value
+			break
+		}
+	}
+
+	engine := c.newEngine(&c.EngineFlags, network, log)
 
 	seedCtx := len(c.ContextValues) > 0 || len(c.ContextFiles) > 0
 	captureCtx := c.IncludeContext

--- a/cmd/crossplane/render/op/cmd.go
+++ b/cmd/crossplane/render/op/cmd.go
@@ -168,7 +168,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		}
 	}
 
-	network := ""
+	var network string
 	for _, annotation := range c.FunctionAnnotations {
 		parts := strings.SplitN(annotation, "=", 2)
 		if len(parts) != 2 {

--- a/cmd/crossplane/render/op/cmd_test.go
+++ b/cmd/crossplane/render/op/cmd_test.go
@@ -259,6 +259,29 @@ func TestCmdRun(t *testing.T) {
 			},
 			want: want{err: cmpopts.AnyError},
 		},
+		"FunctionAnnotationNetworkDefaultsEngineNetwork": {
+			reason: "A runtime Docker network supplied by --function-annotations should default the Crossplane engine Docker network before the engine is created.",
+			args: args{
+				cmd: Cmd{
+					Operation:           "operation.yaml",
+					Functions:           "functions.yaml",
+					FunctionAnnotations: []string{render.AnnotationKeyRuntimeDockerNetwork + "=override-network"},
+					Timeout:             time.Minute,
+					fs:                  newTestFS(nil),
+					newEngine: func(flags *render.EngineFlags, _ logging.Logger) render.Engine {
+						if diff := cmp.Diff("override-network", flags.CrossplaneDockerNetwork); diff != "" {
+							t.Errorf("CrossplaneDockerNetwork: -want, +got:\n%s", diff)
+						}
+						return &render.MockEngine{
+							MockSetup: func(_ context.Context, _ []pkgv1.Function) (func(), error) {
+								return func() {}, errors.New("setup blew up")
+							},
+						}
+					},
+				},
+			},
+			want: want{err: cmpopts.AnyError},
+		},
 		"LoadFunctionCredentialsError": {
 			reason: "Missing function credentials file should return a wrapped load error.",
 			args: args{

--- a/cmd/crossplane/render/op/cmd_test.go
+++ b/cmd/crossplane/render/op/cmd_test.go
@@ -63,8 +63,8 @@ var includeFunctionResultsOutput string
 //go:embed testdata/cmd/output/include-full-operation.yaml
 var includeFullOperationOutput string
 
-func newEngineFunc(engine render.Engine) func(*render.EngineFlags, string, logging.Logger) render.Engine {
-	return func(*render.EngineFlags, string, logging.Logger) render.Engine {
+func newEngineFunc(engine render.Engine) func(*render.EngineFlags, logging.Logger) render.Engine {
+	return func(*render.EngineFlags, logging.Logger) render.Engine {
 		return engine
 	}
 }

--- a/cmd/crossplane/render/op/cmd_test.go
+++ b/cmd/crossplane/render/op/cmd_test.go
@@ -63,8 +63,8 @@ var includeFunctionResultsOutput string
 //go:embed testdata/cmd/output/include-full-operation.yaml
 var includeFullOperationOutput string
 
-func newEngineFunc(engine render.Engine) func(*render.EngineFlags, logging.Logger) render.Engine {
-	return func(*render.EngineFlags, logging.Logger) render.Engine {
+func newEngineFunc(engine render.Engine) func(*render.EngineFlags, string, logging.Logger) render.Engine {
+	return func(*render.EngineFlags, string, logging.Logger) render.Engine {
 		return engine
 	}
 }

--- a/cmd/crossplane/render/render.go
+++ b/cmd/crossplane/render/render.go
@@ -151,7 +151,8 @@ func RewriteAddressesForDocker(fns []*renderv1alpha1.FunctionInput) []*renderv1a
 	return fns
 }
 
-// injectNetworkAnnotation sets the Docker network annotation on all functions
+// injectNetworkAnnotation sets the Docker network annotation
+// on all functions without existing runtime-docker-network annotation
 // so their containers join the specified network.
 func injectNetworkAnnotation(fns []pkgv1.Function, networkName string) {
 	for i := range fns {

--- a/cmd/crossplane/render/render.go
+++ b/cmd/crossplane/render/render.go
@@ -158,7 +158,11 @@ func injectNetworkAnnotation(fns []pkgv1.Function, networkName string) {
 		if fns[i].Annotations == nil {
 			fns[i].Annotations = make(map[string]string)
 		}
-		fns[i].Annotations[AnnotationKeyRuntimeDockerNetwork] = networkName
+
+		_, ok := fns[i].Annotations[AnnotationKeyRuntimeDockerNetwork]
+		if !ok {
+			fns[i].Annotations[AnnotationKeyRuntimeDockerNetwork] = networkName
+		}
 	}
 }
 

--- a/cmd/crossplane/render/render_test.go
+++ b/cmd/crossplane/render/render_test.go
@@ -1,0 +1,93 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+)
+
+func TestOverrideFunctionAnnotations(t *testing.T) {
+	type args struct {
+		functions   []pkgv1.Function
+		annotations []string
+	}
+	type want struct {
+		functions []pkgv1.Function
+		err       error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"AnnotationsAreAppliedToAllFunctions": {
+			reason: "Function annotation flags are global overrides applied to every function before rendering.",
+			args: args{
+				functions: []pkgv1.Function{
+					functionWithAnnotations(map[string]string{"example.org/existing": "value"}),
+					functionWithAnnotations(nil),
+				},
+				annotations: []string{"example.org/override=override-value"},
+			},
+			want: want{
+				functions: []pkgv1.Function{
+					functionWithAnnotations(map[string]string{"example.org/existing": "value", "example.org/override": "override-value"}),
+					functionWithAnnotations(map[string]string{"example.org/override": "override-value"}),
+				},
+			},
+		},
+		"ExistingAnnotationIsOverridden": {
+			reason: "A function annotation flag should replace an existing annotation with the same key.",
+			args: args{
+				functions: []pkgv1.Function{
+					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: "function-network"}),
+				},
+				annotations: []string{AnnotationKeyRuntimeDockerNetwork + "=override-network"},
+			},
+			want: want{
+				functions: []pkgv1.Function{
+					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: "override-network"}),
+				},
+			},
+		},
+		"InvalidAnnotationReturnsError": {
+			reason: "Invalid function annotation flags should fail instead of being silently ignored.",
+			args: args{
+				functions: []pkgv1.Function{
+					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: "function-network"}),
+				},
+				annotations: []string{"malformed"},
+			},
+			want: want{
+				functions: []pkgv1.Function{
+					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: "function-network"}),
+				},
+				err: cmpopts.AnyError,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Log(tc.reason)
+
+			err := OverrideFunctionAnnotations(tc.args.functions, tc.args.annotations)
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("OverrideFunctionAnnotations(...), -want, +got:\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.want.functions, tc.args.functions); diff != "" {
+				t.Errorf("OverrideFunctionAnnotations(...), -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func functionWithAnnotations(annotations map[string]string) pkgv1.Function {
+	return pkgv1.Function{ObjectMeta: metav1.ObjectMeta{Annotations: annotations}}
+}

--- a/cmd/crossplane/render/xr/cmd.go
+++ b/cmd/crossplane/render/xr/cmd.go
@@ -233,7 +233,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		if len(c.FunctionAnnotations) > 0 {
 			annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
 			if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.EngineFlags.CrossplaneDockerNetwork = value
+				c.CrossplaneDockerNetwork = value
 			}
 		}
 	}

--- a/cmd/crossplane/render/xr/cmd.go
+++ b/cmd/crossplane/render/xr/cmd.go
@@ -220,23 +220,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		}
 	}
 
-	if c.CrossplaneDockerNetwork == "" {
-		// Default to the first docker-network annotation in the provided functions
-		for _, fn := range fns {
-			if value, ok := fn.Annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.CrossplaneDockerNetwork = value
-				break
-			}
-		}
-
-		// Overwrite with docker-network annotation from function-annotations cli flag if set
-		if len(c.FunctionAnnotations) > 0 {
-			annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
-			if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.CrossplaneDockerNetwork = value
-			}
-		}
-	}
+	c.SetDefaultCrossplaneDockerNetwork(fns)
 
 	engine := c.newEngine(&c.EngineFlags, log)
 

--- a/cmd/crossplane/render/xr/cmd.go
+++ b/cmd/crossplane/render/xr/cmd.go
@@ -224,7 +224,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		// Default to the first docker-network annotation in the provided functions
 		for _, fn := range fns {
 			if value, ok := fn.Annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.CrossplaneDockerNetwork = value
+				c.EngineFlags.CrossplaneDockerNetwork = value
 				break
 			}
 		}
@@ -233,7 +233,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		if len(c.FunctionAnnotations) > 0 {
 			annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
 			if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.CrossplaneDockerNetwork = value
+				c.EngineFlags.CrossplaneDockerNetwork = value
 			}
 		}
 	}

--- a/cmd/crossplane/render/xr/cmd.go
+++ b/cmd/crossplane/render/xr/cmd.go
@@ -220,7 +220,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		}
 	}
 
-	network := ""
+	var network string
 	for _, annotation := range c.FunctionAnnotations {
 		parts := strings.SplitN(annotation, "=", 2)
 		if len(parts) != 2 {

--- a/cmd/crossplane/render/xr/cmd.go
+++ b/cmd/crossplane/render/xr/cmd.go
@@ -221,16 +221,9 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 	}
 
 	var network string
-	for _, annotation := range c.FunctionAnnotations {
-		parts := strings.SplitN(annotation, "=", 2)
-		if len(parts) != 2 {
-			return errors.Errorf("invalid function annotation format %q, expected key=value", annotation)
-		}
-		key, value := parts[0], parts[1]
-		if key == render.AnnotationKeyRuntimeDockerNetwork {
-			network = value
-			break
-		}
+	annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
+	if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
+		network = value
 	}
 
 	engine := c.newEngine(&c.EngineFlags, network, log)

--- a/cmd/crossplane/render/xr/cmd.go
+++ b/cmd/crossplane/render/xr/cmd.go
@@ -220,11 +220,11 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		}
 	}
 
-	if c.EngineFlags.CrossplaneDockerNetwork == "" {
+	if c.CrossplaneDockerNetwork == "" {
 		// Default to the first docker-network annotation in the provided functions
 		for _, fn := range fns {
 			if value, ok := fn.Annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.EngineFlags.CrossplaneDockerNetwork = value
+				c.CrossplaneDockerNetwork = value
 				break
 			}
 		}
@@ -233,7 +233,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		if len(c.FunctionAnnotations) > 0 {
 			annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
 			if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-				c.EngineFlags.CrossplaneDockerNetwork = value
+				c.CrossplaneDockerNetwork = value
 			}
 		}
 	}

--- a/cmd/crossplane/render/xr/cmd.go
+++ b/cmd/crossplane/render/xr/cmd.go
@@ -93,7 +93,7 @@ type Cmd struct {
 	fs afero.Fs
 
 	// newEngine constructs the render Engine.
-	newEngine func(*render.EngineFlags, logging.Logger) render.Engine
+	newEngine func(*render.EngineFlags, string, logging.Logger) render.Engine
 }
 
 // Help prints out the help for the render command.
@@ -220,7 +220,20 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		}
 	}
 
-	engine := c.newEngine(&c.EngineFlags, log)
+	network := ""
+	for _, annotation := range c.FunctionAnnotations {
+		parts := strings.SplitN(annotation, "=", 2)
+		if len(parts) != 2 {
+			return errors.Errorf("invalid function annotation format %q, expected key=value", annotation)
+		}
+		key, value := parts[0], parts[1]
+		if key == render.AnnotationKeyRuntimeDockerNetwork {
+			network = value
+			break
+		}
+	}
+
+	engine := c.newEngine(&c.EngineFlags, network, log)
 
 	seedCtx := len(c.ContextValues) > 0 || len(c.ContextFiles) > 0
 	captureCtx := c.IncludeContext

--- a/cmd/crossplane/render/xr/cmd.go
+++ b/cmd/crossplane/render/xr/cmd.go
@@ -93,7 +93,7 @@ type Cmd struct {
 	fs afero.Fs
 
 	// newEngine constructs the render Engine.
-	newEngine func(*render.EngineFlags, string, logging.Logger) render.Engine
+	newEngine func(*render.EngineFlags, logging.Logger) render.Engine
 }
 
 // Help prints out the help for the render command.
@@ -220,13 +220,25 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 		}
 	}
 
-	var network string
-	annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
-	if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
-		network = value
+	if c.EngineFlags.CrossplaneDockerNetwork == "" {
+		// Default to the first docker-network annotation in the provided functions
+		for _, fn := range fns {
+			if value, ok := fn.Annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
+				c.CrossplaneDockerNetwork = value
+				break
+			}
+		}
+
+		// Overwrite with docker-network annotation from function-annotations cli flag if set
+		if len(c.FunctionAnnotations) > 0 {
+			annotations := render.NewAnnotationsFromStrings(c.FunctionAnnotations)
+			if value, ok := annotations[render.AnnotationKeyRuntimeDockerNetwork]; ok {
+				c.EngineFlags.CrossplaneDockerNetwork = value
+			}
+		}
 	}
 
-	engine := c.newEngine(&c.EngineFlags, network, log)
+	engine := c.newEngine(&c.EngineFlags, log)
 
 	seedCtx := len(c.ContextValues) > 0 || len(c.ContextFiles) > 0
 	captureCtx := c.IncludeContext

--- a/cmd/crossplane/render/xr/cmd_test.go
+++ b/cmd/crossplane/render/xr/cmd_test.go
@@ -299,6 +299,30 @@ func TestCmdRun(t *testing.T) {
 			},
 			want: want{err: cmpopts.AnyError},
 		},
+		"FunctionAnnotationNetworkDefaultsEngineNetwork": {
+			reason: "A runtime Docker network supplied by --function-annotations should default the Crossplane engine Docker network before the engine is created.",
+			args: args{
+				cmd: Cmd{
+					CompositeResource:   "xr.yaml",
+					Composition:         "composition.yaml",
+					Functions:           "functions.yaml",
+					FunctionAnnotations: []string{render.AnnotationKeyRuntimeDockerNetwork + "=override-network"},
+					Timeout:             time.Minute,
+					fs:                  newTestFS(nil),
+					newEngine: func(flags *render.EngineFlags, _ logging.Logger) render.Engine {
+						if diff := cmp.Diff("override-network", flags.CrossplaneDockerNetwork); diff != "" {
+							t.Errorf("CrossplaneDockerNetwork: -want, +got:\n%s", diff)
+						}
+						return &render.MockEngine{
+							MockSetup: func(_ context.Context, _ []pkgv1.Function) (func(), error) {
+								return func() {}, errors.New("setup blew up")
+							},
+						}
+					},
+				},
+			},
+			want: want{err: cmpopts.AnyError},
+		},
 		"LoadXRDError": {
 			reason: "Missing XRD file should return a wrapped load error.",
 			args: args{

--- a/cmd/crossplane/render/xr/cmd_test.go
+++ b/cmd/crossplane/render/xr/cmd_test.go
@@ -78,8 +78,8 @@ var includeFunctionResultsOutput string
 //go:embed testdata/cmd/output/include-full-xr.yaml
 var includeFullXROutput string
 
-func newEngineFunc(engine render.Engine) func(*render.EngineFlags, logging.Logger) render.Engine {
-	return func(*render.EngineFlags, logging.Logger) render.Engine {
+func newEngineFunc(engine render.Engine) func(*render.EngineFlags, string, logging.Logger) render.Engine {
+	return func(*render.EngineFlags, string, logging.Logger) render.Engine {
 		return engine
 	}
 }

--- a/cmd/crossplane/render/xr/cmd_test.go
+++ b/cmd/crossplane/render/xr/cmd_test.go
@@ -78,8 +78,8 @@ var includeFunctionResultsOutput string
 //go:embed testdata/cmd/output/include-full-xr.yaml
 var includeFullXROutput string
 
-func newEngineFunc(engine render.Engine) func(*render.EngineFlags, string, logging.Logger) render.Engine {
-	return func(*render.EngineFlags, string, logging.Logger) render.Engine {
+func newEngineFunc(engine render.Engine) func(*render.EngineFlags, logging.Logger) render.Engine {
+	return func(*render.EngineFlags, logging.Logger) render.Engine {
 		return engine
 	}
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->
Closes https://github.com/crossplane/cli/issues/75

Fixes:

- Do not overwrite the docker-network annotation in functions if it has already been set
- If the docker-network annotation is passed to the `FunctionAnnotations` flag, run crossplane-container in it.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
