### PR TITLE
render: Sync render.proto with c/c and wire XRD through

### DIFF
--- a/cmd/crossplane/render/convert.go
+++ b/cmd/crossplane/render/convert.go
@@ -77,17 +77,26 @@ func BuildCompositeRequest(in CompositionInputs) (*renderv1alpha1.RenderRequest,
 		return nil, errors.Wrap(err, "cannot convert required schemas to protobuf")
 	}
 
+	var xrdStruct *structpb.Struct
+	if in.XRD != nil {
+		xrdStruct, err = resource.AsStruct(in.XRD)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot convert XRD to protobuf")
+		}
+	}
+
 	return &renderv1alpha1.RenderRequest{
 		Meta: &renderv1alpha1.RequestMeta{},
 		Input: &renderv1alpha1.RenderRequest_Composite{
 			Composite: &renderv1alpha1.CompositeInput{
-				CompositeResource: xrStruct,
-				Composition:       compStruct,
-				Functions:         fnInputs,
-				ObservedResources: observedStructs,
-				RequiredResources: requiredStructs,
-				RequiredSchemas:   schemaStructs,
-				Credentials:       credStructs,
+				CompositeResource:           xrStruct,
+				Composition:                 compStruct,
+				Functions:                   fnInputs,
+				ObservedResources:           observedStructs,
+				RequiredResources:           requiredStructs,
+				RequiredSchemas:             schemaStructs,
+				Credentials:                 credStructs,
+				CompositeResourceDefinition: xrdStruct,
 			},
 		},
 	}, nil

--- a/cmd/crossplane/render/render.go
+++ b/cmd/crossplane/render/render.go
@@ -59,6 +59,13 @@ type CompositionInputs struct {
 	ObservedResources   []composed.Unstructured
 	RequiredResources   []kunstructured.Unstructured
 	RequiredSchemas     []spec3.OpenAPI
+
+	// XRD is the CompositeResourceDefinition the binary should consider
+	// when rendering. The binary uses it to pick the right composite.Schema
+	// (Legacy vs Modern) for the input XR's GVK, mirroring the production
+	// reconciler. Optional; when nil the binary falls back to its default
+	// behavior (Schema=Modern).
+	XRD *kunstructured.Unstructured
 }
 
 // CompositionOutputs contains all outputs from the render process.

--- a/proto/render/v1alpha1/render.pb.go
+++ b/proto/render/v1alpha1/render.pb.go
@@ -513,8 +513,19 @@ type CompositeInput struct {
 	// request schemas via the Requirements protocol. Each entry is a full OpenAPI
 	// v3 document as JSON. Optional.
 	RequiredSchemas []*structpb.Struct `protobuf:"bytes,7,rep,name=required_schemas,json=requiredSchemas,proto3" json:"required_schemas,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// CompositeResourceDefinition is the XRD that defines the input XR. The
+	// binary uses it to determine the right composite.Schema (Legacy vs Modern),
+	// mirroring what the production reconciler does. Its composite GVK must
+	// match the input XR.
+	//
+	// Render does not recurse into composed XRs. Callers that need to render
+	// a chain of nested XRs should invoke render once per XR, supplying the
+	// matching XRD on each call.
+	//
+	// Optional. If absent, the binary falls back to Schema=Modern.
+	CompositeResourceDefinition *structpb.Struct `protobuf:"bytes,8,opt,name=composite_resource_definition,json=compositeResourceDefinition,proto3" json:"composite_resource_definition,omitempty"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *CompositeInput) Reset() {
@@ -592,6 +603,13 @@ func (x *CompositeInput) GetCredentials() []*structpb.Struct {
 func (x *CompositeInput) GetRequiredSchemas() []*structpb.Struct {
 	if x != nil {
 		return x.RequiredSchemas
+	}
+	return nil
+}
+
+func (x *CompositeInput) GetCompositeResourceDefinition() *structpb.Struct {
+	if x != nil {
+		return x.CompositeResourceDefinition
 	}
 	return nil
 }
@@ -1090,7 +1108,7 @@ const file_proto_render_v1alpha1_render_proto_rawDesc = "" +
 	"\x05Event\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage\"\xeb\x03\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\"\xc8\x04\n" +
 	"\x0eCompositeInput\x12F\n" +
 	"\x12composite_resource\x18\x01 \x01(\v2\x17.google.protobuf.StructR\x11compositeResource\x129\n" +
 	"\vcomposition\x18\x02 \x01(\v2\x17.google.protobuf.StructR\vcomposition\x12G\n" +
@@ -1098,7 +1116,8 @@ const file_proto_render_v1alpha1_render_proto_rawDesc = "" +
 	"\x12observed_resources\x18\x04 \x03(\v2\x17.google.protobuf.StructR\x11observedResources\x12F\n" +
 	"\x12required_resources\x18\x05 \x03(\v2\x17.google.protobuf.StructR\x11requiredResources\x129\n" +
 	"\vcredentials\x18\x06 \x03(\v2\x17.google.protobuf.StructR\vcredentials\x12B\n" +
-	"\x10required_schemas\x18\a \x03(\v2\x17.google.protobuf.StructR\x0frequiredSchemas\"\xae\x03\n" +
+	"\x10required_schemas\x18\a \x03(\v2\x17.google.protobuf.StructR\x0frequiredSchemas\x12[\n" +
+	"\x1dcomposite_resource_definition\x18\b \x01(\v2\x17.google.protobuf.StructR\x1bcompositeResourceDefinition\"\xae\x03\n" +
 	"\x0fCompositeOutput\x12F\n" +
 	"\x12composite_resource\x18\x01 \x01(\v2\x17.google.protobuf.StructR\x11compositeResource\x12F\n" +
 	"\x12composed_resources\x18\x02 \x03(\v2\x17.google.protobuf.StructR\x11composedResources\x12D\n" +
@@ -1179,33 +1198,34 @@ var file_proto_render_v1alpha1_render_proto_depIdxs = []int32{
 	14, // 14: crossplane.render.v1alpha1.CompositeInput.required_resources:type_name -> google.protobuf.Struct
 	14, // 15: crossplane.render.v1alpha1.CompositeInput.credentials:type_name -> google.protobuf.Struct
 	14, // 16: crossplane.render.v1alpha1.CompositeInput.required_schemas:type_name -> google.protobuf.Struct
-	14, // 17: crossplane.render.v1alpha1.CompositeOutput.composite_resource:type_name -> google.protobuf.Struct
-	14, // 18: crossplane.render.v1alpha1.CompositeOutput.composed_resources:type_name -> google.protobuf.Struct
-	14, // 19: crossplane.render.v1alpha1.CompositeOutput.deleted_resources:type_name -> google.protobuf.Struct
-	5,  // 20: crossplane.render.v1alpha1.CompositeOutput.events:type_name -> crossplane.render.v1alpha1.Event
-	14, // 21: crossplane.render.v1alpha1.CompositeOutput.required_resources:type_name -> google.protobuf.Struct
-	14, // 22: crossplane.render.v1alpha1.CompositeOutput.required_schemas:type_name -> google.protobuf.Struct
-	14, // 23: crossplane.render.v1alpha1.OperationInput.operation:type_name -> google.protobuf.Struct
-	4,  // 24: crossplane.render.v1alpha1.OperationInput.functions:type_name -> crossplane.render.v1alpha1.FunctionInput
-	14, // 25: crossplane.render.v1alpha1.OperationInput.required_resources:type_name -> google.protobuf.Struct
-	14, // 26: crossplane.render.v1alpha1.OperationInput.credentials:type_name -> google.protobuf.Struct
-	14, // 27: crossplane.render.v1alpha1.OperationInput.required_schemas:type_name -> google.protobuf.Struct
-	14, // 28: crossplane.render.v1alpha1.OperationOutput.operation:type_name -> google.protobuf.Struct
-	14, // 29: crossplane.render.v1alpha1.OperationOutput.applied_resources:type_name -> google.protobuf.Struct
-	5,  // 30: crossplane.render.v1alpha1.OperationOutput.events:type_name -> crossplane.render.v1alpha1.Event
-	14, // 31: crossplane.render.v1alpha1.OperationOutput.required_resources:type_name -> google.protobuf.Struct
-	14, // 32: crossplane.render.v1alpha1.OperationOutput.required_schemas:type_name -> google.protobuf.Struct
-	14, // 33: crossplane.render.v1alpha1.CronOperationInput.cron_operation:type_name -> google.protobuf.Struct
-	15, // 34: crossplane.render.v1alpha1.CronOperationInput.scheduled_time:type_name -> google.protobuf.Timestamp
-	14, // 35: crossplane.render.v1alpha1.CronOperationOutput.operation:type_name -> google.protobuf.Struct
-	14, // 36: crossplane.render.v1alpha1.WatchOperationInput.watch_operation:type_name -> google.protobuf.Struct
-	14, // 37: crossplane.render.v1alpha1.WatchOperationInput.watched_resource:type_name -> google.protobuf.Struct
-	14, // 38: crossplane.render.v1alpha1.WatchOperationOutput.operation:type_name -> google.protobuf.Struct
-	39, // [39:39] is the sub-list for method output_type
-	39, // [39:39] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	39, // [39:39] is the sub-list for extension extendee
-	0,  // [0:39] is the sub-list for field type_name
+	14, // 17: crossplane.render.v1alpha1.CompositeInput.composite_resource_definition:type_name -> google.protobuf.Struct
+	14, // 18: crossplane.render.v1alpha1.CompositeOutput.composite_resource:type_name -> google.protobuf.Struct
+	14, // 19: crossplane.render.v1alpha1.CompositeOutput.composed_resources:type_name -> google.protobuf.Struct
+	14, // 20: crossplane.render.v1alpha1.CompositeOutput.deleted_resources:type_name -> google.protobuf.Struct
+	5,  // 21: crossplane.render.v1alpha1.CompositeOutput.events:type_name -> crossplane.render.v1alpha1.Event
+	14, // 22: crossplane.render.v1alpha1.CompositeOutput.required_resources:type_name -> google.protobuf.Struct
+	14, // 23: crossplane.render.v1alpha1.CompositeOutput.required_schemas:type_name -> google.protobuf.Struct
+	14, // 24: crossplane.render.v1alpha1.OperationInput.operation:type_name -> google.protobuf.Struct
+	4,  // 25: crossplane.render.v1alpha1.OperationInput.functions:type_name -> crossplane.render.v1alpha1.FunctionInput
+	14, // 26: crossplane.render.v1alpha1.OperationInput.required_resources:type_name -> google.protobuf.Struct
+	14, // 27: crossplane.render.v1alpha1.OperationInput.credentials:type_name -> google.protobuf.Struct
+	14, // 28: crossplane.render.v1alpha1.OperationInput.required_schemas:type_name -> google.protobuf.Struct
+	14, // 29: crossplane.render.v1alpha1.OperationOutput.operation:type_name -> google.protobuf.Struct
+	14, // 30: crossplane.render.v1alpha1.OperationOutput.applied_resources:type_name -> google.protobuf.Struct
+	5,  // 31: crossplane.render.v1alpha1.OperationOutput.events:type_name -> crossplane.render.v1alpha1.Event
+	14, // 32: crossplane.render.v1alpha1.OperationOutput.required_resources:type_name -> google.protobuf.Struct
+	14, // 33: crossplane.render.v1alpha1.OperationOutput.required_schemas:type_name -> google.protobuf.Struct
+	14, // 34: crossplane.render.v1alpha1.CronOperationInput.cron_operation:type_name -> google.protobuf.Struct
+	15, // 35: crossplane.render.v1alpha1.CronOperationInput.scheduled_time:type_name -> google.protobuf.Timestamp
+	14, // 36: crossplane.render.v1alpha1.CronOperationOutput.operation:type_name -> google.protobuf.Struct
+	14, // 37: crossplane.render.v1alpha1.WatchOperationInput.watch_operation:type_name -> google.protobuf.Struct
+	14, // 38: crossplane.render.v1alpha1.WatchOperationInput.watched_resource:type_name -> google.protobuf.Struct
+	14, // 39: crossplane.render.v1alpha1.WatchOperationOutput.operation:type_name -> google.protobuf.Struct
+	40, // [40:40] is the sub-list for method output_type
+	40, // [40:40] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_proto_render_v1alpha1_render_proto_init() }

--- a/proto/render/v1alpha1/render.proto
+++ b/proto/render/v1alpha1/render.proto
@@ -112,6 +112,18 @@ message CompositeInput {
   // request schemas via the Requirements protocol. Each entry is a full OpenAPI
   // v3 document as JSON. Optional.
   repeated google.protobuf.Struct required_schemas = 7;
+
+  // CompositeResourceDefinition is the XRD that defines the input XR. The
+  // binary uses it to determine the right composite.Schema (Legacy vs Modern),
+  // mirroring what the production reconciler does. Its composite GVK must
+  // match the input XR.
+  //
+  // Render does not recurse into composed XRs. Callers that need to render
+  // a chain of nested XRs should invoke render once per XR, supplying the
+  // matching XRD on each call.
+  //
+  // Optional. If absent, the binary falls back to Schema=Modern.
+  google.protobuf.Struct composite_resource_definition = 8;
 }
 
 // A CompositeOutput contains the results of rendering a composite resource.


### PR DESCRIPTION
### Description of your changes

Two commits:

1. **`proto: Sync render.proto with crossplane/crossplane main`** — adds `composite_resource_definition` (field 8) to `CompositeInput`, matching the upstream proto, and regenerates `render.pb.go` via `./nix.sh run .#generate` (Nix-pinned `protoc-gen-go` v1.36.10). The cli's `option go_package` intentionally still points at `github.com/crossplane/cli/v2/proto/render/v1alpha1`; after that one line the proto file is byte-identical to upstream `main`.

2. **`render: wire CompositionInputs.XRD through to the proto`** — adds an `XRD *unstructured.Unstructured` field to `CompositionInputs` and threads it through `BuildCompositeRequest` to the proto's `CompositeResourceDefinition`. When the caller leaves `XRD` nil, behavior is unchanged: the field stays unset and the render binary keeps its `Schema=Modern` fallback. This mirrors the Go-level change in `crossplane/crossplane/cmd/crossplane/render` so the cli's `CompositionInputs` stays in sync with what the binary now consumes.

Picking up an XRD from disk / the `--extra-resources` flag and populating `CompositionInputs.XRD` at the call sites (e.g. `cmd/crossplane/render/xr/cmd.go`) is intentionally out of scope here — that's a separate UX-shaped change. After this PR the plumbing is in place; the field is available to any caller that wants to use it.

Upstream proto changes:
- crossplane/crossplane@12f3f1c (adds the field; `composite_resource_definitions` plural at the time)
- crossplane/crossplane@babb251 (review feedback: collapses to singular `composite_resource_definition`; this PR matches the post-feedback shape on `main`)

How this is covered by tests: regen is mechanical, and the wiring commit is pure plumbing — leaving `CompositionInputs.XRD` nil produces the same proto request as before, so the existing `cmd/crossplane/render/...` tests cover the no-XRD path. `./nix.sh flake check` passes.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~~Added or updated unit tests.~~ Regen + nil-default plumbing; the existing render tests cover the unchanged no-XRD path. Happy to add a test that asserts the XRD-set path produces the populated proto field if reviewers want it.
- [ ] ~~Linked a PR or a [docs tracking issue] to [document this change].~~ No user-facing change yet — this PR adds the proto field and the `CompositionInputs.XRD` plumbing; there's no command-surface change to document.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~ Not a backport candidate; happy to add a label if maintainers want it on a release branch.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute