### PR TITLE
Update the CLI docs path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,13 +202,13 @@ jobs:
         run: |
           chmod +x ./bin/linux_amd64/crossplane
           ./bin/linux_amd64/crossplane config set features.enableAlpha true
-          ./bin/linux_amd64/crossplane generate-docs -o ./docs/content/master/cli/command-reference.md
+          ./bin/linux_amd64/crossplane generate-docs -o ./docs/content/cli/master/command-reference.md
 
       - name: Run Vale
         uses: vale-cli/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         with:
           version: "3.14.2"
-          files: ./docs/content/master/cli/command-reference.md
+          files: ./docs/content/cli/master/command-reference.md
           vale_flags: "--config=./docs/utils/vale/.vale.ini"
           fail_on_error: true
           reporter: local
@@ -217,4 +217,4 @@ jobs:
       - name: Show generated docs on failure
         if: ${{ failure() }}
         run: |
-          cat ./docs/content/master/cli/command-reference.md
+          cat ./docs/content/cli/master/command-reference.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ git clone https://github.com/crossplane/docs.git
 cd docs
 
 # Generate the docs.
-crossplane generate-docs -o content/master/cli/command-reference.md
+crossplane generate-docs -o content/cli/master/command-reference.md
 
 # Build the docs and serve them locally for preview.
 hugo serve

--- a/cmd/crossplane/docs-templates/command-reference.md.tmpl
+++ b/cmd/crossplane/docs-templates/command-reference.md.tmpl
@@ -1,5 +1,5 @@
 ---
-weight: 50
+weight: 100
 title: Command Reference
 description: "Command reference for the Crossplane CLI"
 ---

--- a/cmd/crossplane/xpkg/init.go
+++ b/cmd/crossplane/xpkg/init.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/alecthomas/kong"
@@ -69,7 +71,13 @@ type initCmd struct {
 
 func (c *initCmd) Help() string {
 	b := strings.Builder{}
-	for name, url := range WellKnownTemplates() {
+
+	// Sort the map keys to ensure stable help output.
+	tmpls := WellKnownTemplates()
+	names := slices.Sorted(maps.Keys(tmpls))
+
+	for _, name := range names {
+		url := tmpls[name]
 		fmt.Fprintf(&b, "- `%s` ([%s](%s))\n", name, url, url)
 	}
 


### PR DESCRIPTION
### Description of your changes

The CLI docs are now versioned separately from the rest of the docs, in preparation for the CLI version diverging from core. Update it in our contributing docs and the CI jobs where we validate generated docs changes. Also update the docs template to match the current documentation page.

While we're here, make the dynamically generated help for `crossplane xpkg init` stable across runs by sorting the template names. This will reduce unnecessary churn when we automate docs updates.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
