### PR TITLE
fix(render): resolve xcrd import conflict

### DIFF
--- a/cmd/crossplane/render/xr/cmd.go
+++ b/cmd/crossplane/render/xr/cmd.go
@@ -342,10 +342,10 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 	slices.SortStableFunc(out.ComposedResources, func(a, b composed.Unstructured) int {
 		nameA, nameB := "", ""
 		if anns := a.GetAnnotations(); anns != nil {
-			nameA = anns[xcrd.AnnotationKeyCompositionResourceName]
+			nameA = anns[xrpkg.AnnotationKeyCompositionResourceName]
 		}
 		if anns := b.GetAnnotations(); anns != nil {
-			nameB = anns[xcrd.AnnotationKeyCompositionResourceName]
+			nameB = anns[xrpkg.AnnotationKeyCompositionResourceName]
 		}
 
 		return strings.Compare(nameA, nameB)
@@ -359,7 +359,7 @@ func (c *Cmd) Run(k *kong.Context, log logging.Logger, sp terminal.SpinnerPrinte
 	for i := range out.ComposedResources {
 		_, _ = fmt.Fprintln(k.Stdout, "---")
 		if err := s.Encode(&out.ComposedResources[i], k.Stdout); err != nil {
-			return errors.Wrapf(err, "cannot marshal composed resource %q to YAML", out.ComposedResources[i].GetAnnotations()[xcrd.AnnotationKeyCompositionResourceName])
+			return errors.Wrapf(err, "cannot marshal composed resource %q to YAML", out.ComposedResources[i].GetAnnotations()[xrpkg.AnnotationKeyCompositionResourceName])
 		}
 	}
 

--- a/pkg/xr/xrd.go
+++ b/pkg/xr/xrd.go
@@ -30,6 +30,11 @@ import (
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1"
 )
 
+// AnnotationKeyCompositionResourceName is the annotation that records a
+// composed resource's name within the composition. Re-exported from
+// crossplane-runtime so callers don't need a direct dependency on xcrd.
+const AnnotationKeyCompositionResourceName = xcrd.AnnotationKeyCompositionResourceName
+
 // ApplyXRDDefaults applies default values from an XRD's openAPIV3Schema to an XR. The XR is mutated in place.
 // This is the canonical XRD-defaulting entry point for the cli; downstream
 // commands and tools (e.g. `crossplane render xr --xrd`) call into this


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

PR#61 removed the xcrd import from `render/xr/cmd.go` by moving the XRD logic into `pkg/xr`. Meanwhile, PR#82 added composed resource sorting reintroducing the dependency.

This commit sets a new constant from `pkg.xr` which already imports `xcrd` so that the render command only depends on `pkg/xr` (`xrpkg`).

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
