### PR TITLE
Add repository option to `crossplane project init`

### DIFF
--- a/cmd/crossplane/project/init.go
+++ b/cmd/crossplane/project/init.go
@@ -38,9 +38,9 @@ const projectFileName = "crossplane-project.yaml"
 
 // initCmd initializes a new project.
 type initCmd struct {
-	Name       string `arg:""                       help:"The name of the new project."`
-	Directory  string `arg:""                       help:"Directory to initialize. Defaults to project name." optional:"" short:"d" type:"path"`
-	Repository string `default:"example.com/my-org" help:"Override the repository in the project file."       optional:""`
+	Name       string `arg:""                                                    help:"The name of the new project."`
+	Directory  string `help:"Directory to initialize. Defaults to project name." short:"d"                                           type:"path"`
+	Repository string `default:"example.com/my-org"                              help:"Override the repository in the project file." optional:"" short:"r"`
 }
 
 func (c *initCmd) Help() string {
@@ -62,6 +62,10 @@ func (c *initCmd) Run(sp terminal.SpinnerPrinter) error {
 		return err
 	}
 
+	repo := strings.TrimRight(c.Repository, "/")
+	if repo == "" {
+		return errors.New("repository cannot be empty; set --repository to an OCI repository prefix like 'xpkg.crossplane.io/my-org'")
+	}
 	return sp.WrapWithSuccessSpinner("Initializing project", func() error {
 		if err := os.MkdirAll(c.Directory, 0o750); err != nil {
 			return errors.Wrapf(err, "failed to create directory %s", c.Directory)
@@ -75,7 +79,7 @@ metadata:
   name: %s
 spec:
   repository: %s/%s
-`, c.Name, c.Repository, c.Name)
+`, c.Name, repo, c.Name)
 
 		if err := os.WriteFile(projFile, []byte(content), 0o600); err != nil {
 			return errors.Wrapf(err, "failed to write %s", projectFileName)

--- a/cmd/crossplane/project/init.go
+++ b/cmd/crossplane/project/init.go
@@ -62,7 +62,7 @@ func (c *initCmd) Run(sp terminal.SpinnerPrinter) error {
 		return err
 	}
 
-	repo := strings.TrimRight(c.Repository, "/")
+	repo := strings.TrimRight(strings.TrimSpace(c.Repository), "/")
 	if repo == "" {
 		return errors.New("repository cannot be empty; set --repository to an OCI repository prefix like 'xpkg.crossplane.io/my-org'")
 	}

--- a/cmd/crossplane/project/init.go
+++ b/cmd/crossplane/project/init.go
@@ -38,8 +38,9 @@ const projectFileName = "crossplane-project.yaml"
 
 // initCmd initializes a new project.
 type initCmd struct {
-	Name      string `arg:""                                                    help:"The name of the new project."`
-	Directory string `help:"Directory to initialize. Defaults to project name." short:"d"                           type:"path"`
+	Name       string `arg:""                       help:"The name of the new project."`
+	Directory  string `arg:""                       help:"Directory to initialize. Defaults to project name." optional:"" short:"d" type:"path"`
+	Repository string `default:"example.com/my-org" help:"Override the repository in the project file."       optional:""`
 }
 
 func (c *initCmd) Help() string {
@@ -73,8 +74,8 @@ kind: Project
 metadata:
   name: %s
 spec:
-  repository: example.com/my-org/%s
-`, c.Name, c.Name)
+  repository: %s/%s
+`, c.Name, c.Repository, c.Name)
 
 		if err := os.WriteFile(projFile, []byte(content), 0o600); err != nil {
 			return errors.Wrapf(err, "failed to write %s", projectFileName)

--- a/cmd/crossplane/project/init.go
+++ b/cmd/crossplane/project/init.go
@@ -39,10 +39,10 @@ const projectFileName = "crossplane-project.yaml"
 
 // initCmd initializes a new project.
 type initCmd struct {
-	Name       string `arg:""                                                    help:"The name of the new project."`
-	Directory  string `help:"Directory to initialize. Defaults to project name." short:"d"                                                                               type:"path"`
-	Registry   string `default:"example.com/my-org"                              help:"Override the registry in the project file."                                       optional:"" short:"r"`
-	Repository string `help:"Override the repository name in the project file.  Defaults to the project name." optional:""`
+	Name       string `arg:""                                                                                 help:"The name of the new project."`
+	Directory  string `help:"Directory to initialize. Defaults to project name"                               short:"d"                                         type:"path"`
+	Registry   string `default:"example.com/my-org"                                                           help:"Override the registry in the project file." optional:"" short:"r"`
+	Repository string `help:"Override the repository name in the project file. Defaults to the project name." optional:""`
 }
 
 func (c *initCmd) Help() string {
@@ -68,12 +68,12 @@ func (c *initCmd) Run(sp terminal.SpinnerPrinter) error {
 
 	rp := strings.TrimRight(strings.TrimSpace(c.Registry), "/")
 	if rp == "" {
-		return errors.New("registry cannot be empty; set --registryPath to an OCI registry prefix like 'xpkg.crossplane.io/my-org'")
+		return errors.New("registry cannot be empty; set --registry to an OCI registry prefix like 'xpkg.crossplane.io/my-org'")
 	}
 
 	r, err := name.NewRepository(rp + "/" + c.Repository)
 	if err != nil {
-		return errors.Wrapf(err, "cannot build function reference from repository \"%s/%s\"", rp, c.Repository)
+		return errors.Wrapf(err, "cannot build repository \"%s/%s\"", rp, c.Repository)
 	}
 
 	return sp.WrapWithSuccessSpinner("Initializing project", func() error {

--- a/cmd/crossplane/project/init.go
+++ b/cmd/crossplane/project/init.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
@@ -39,8 +40,9 @@ const projectFileName = "crossplane-project.yaml"
 // initCmd initializes a new project.
 type initCmd struct {
 	Name       string `arg:""                                                    help:"The name of the new project."`
-	Directory  string `help:"Directory to initialize. Defaults to project name." short:"d"                                           type:"path"`
-	Repository string `default:"example.com/my-org"                              help:"Override the repository in the project file." optional:"" short:"r"`
+	Directory  string `help:"Directory to initialize. Defaults to project name." short:"d"                                                                               type:"path"`
+	Registry   string `default:"example.com/my-org"                              help:"Override the registry in the project file."                                       optional:"" short:"r"`
+	Repository string `help:"Override the repository name in the project file.  Defaults to the project name." optional:""`
 }
 
 func (c *initCmd) Help() string {
@@ -56,16 +58,24 @@ func (c *initCmd) Run(sp terminal.SpinnerPrinter) error {
 	if c.Directory == "" {
 		c.Directory = c.Name
 	}
-
+	if strings.TrimSpace(c.Repository) == "" {
+		c.Repository = c.Name
+	}
 	// Check if the target directory is suitable.
 	if err := c.checkTargetDirectory(); err != nil {
 		return err
 	}
 
-	repo := strings.TrimRight(strings.TrimSpace(c.Repository), "/")
-	if repo == "" {
-		return errors.New("repository cannot be empty; set --repository to an OCI repository prefix like 'xpkg.crossplane.io/my-org'")
+	rp := strings.TrimRight(strings.TrimSpace(c.Registry), "/")
+	if rp == "" {
+		return errors.New("registry cannot be empty; set --registryPath to an OCI registry prefix like 'xpkg.crossplane.io/my-org'")
 	}
+
+	r, err := name.NewRepository(rp + "/" + c.Repository)
+	if err != nil {
+		return errors.Wrapf(err, "cannot build function reference from repository \"%s/%s\"", rp, c.Repository)
+	}
+
 	return sp.WrapWithSuccessSpinner("Initializing project", func() error {
 		if err := os.MkdirAll(c.Directory, 0o750); err != nil {
 			return errors.Wrapf(err, "failed to create directory %s", c.Directory)
@@ -78,8 +88,8 @@ kind: Project
 metadata:
   name: %s
 spec:
-  repository: %s/%s
-`, c.Name, repo, c.Name)
+  repository: %s
+`, c.Name, r.String())
 
 		if err := os.WriteFile(projFile, []byte(content), 0o600); err != nil {
 			return errors.Wrapf(err, "failed to write %s", projectFileName)


### PR DESCRIPTION
### Description of your changes

Added the `--repository` option to `crossplane project init` to override the default `example.com/my-org` values.

Made the directory name truly optional.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [X] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
