### PR TITLE
ci: Re-use exising docs PRs and sign off on commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,10 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           path: ./docs
-          commit-message: Update master CLI reference docs for ${{ needs.build-artifacts.outputs.version }}
+          commit-message: |
+            Update master CLI reference docs for ${{ needs.build-artifacts.outputs.version }}
+
+            Signed-off-by: cli-docs-bot <info@crossplane.io>
           title: Update master CLI reference docs for ${{ needs.build-artifacts.outputs.version }}
           # We use a static branch name so that if an existing PR is already
           # open it gets updated, rather than opening a sequence of PRs of which

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,5 +262,8 @@ jobs:
           path: ./docs
           commit-message: Update master CLI reference docs for ${{ needs.build-artifacts.outputs.version }}
           title: Update master CLI reference docs for ${{ needs.build-artifacts.outputs.version }}
-          branch: cli-docs-${{ needs.build-artifacts.outputs.version }}
+          # We use a static branch name so that if an existing PR is already
+          # open it gets updated, rather than opening a sequence of PRs of which
+          # it makes sense to merge only the most recent.
+          branch: auto-update-cli-docs
           add-paths: content/cli/master/command-reference.md


### PR DESCRIPTION
### Description of your changes

Set a static branch name in the `create-pull-request` action that updates the reference docs so that if an existing docs update PR is open it will be re-used. This avoids creating a sequence of PRs (of which it makes sense to merge only the most recent) if we don't review and merge them right away.

While we're here, also update the docs update job to add a `Signed-off-by` line to its commit message. This should make the DCO check in the docs repo pass, avoiding the need for a bypass merge.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
