### PR TITLE
ci: Make cli-docs-bot the author of docs update commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,11 +260,9 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           path: ./docs
-          commit-message: |
-            Update master CLI reference docs for ${{ needs.build-artifacts.outputs.version }}
-
-            Signed-off-by: cli-docs-bot <info@crossplane.io>
+          commit-message: Update master CLI reference docs for ${{ needs.build-artifacts.outputs.version }}
           author: cli-docs-bot <info@crossplane.io>
+          signoff: true
           title: Update master CLI reference docs for ${{ needs.build-artifacts.outputs.version }}
           # We use a static branch name so that if an existing PR is already
           # open it gets updated, rather than opening a sequence of PRs of which

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,7 @@ jobs:
             Update master CLI reference docs for ${{ needs.build-artifacts.outputs.version }}
 
             Signed-off-by: cli-docs-bot <info@crossplane.io>
+          author: cli-docs-bot <info@crossplane.io>
           title: Update master CLI reference docs for ${{ needs.build-artifacts.outputs.version }}
           # We use a static branch name so that if an existing PR is already
           # open it gets updated, rather than opening a sequence of PRs of which


### PR DESCRIPTION
### Description of your changes

The Signed-off-by line should match the commit author, and this also makes it clearer that the docs update was automated rather than being done by a human.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
