### PR TITLE
xrd: Handle v2 XRDs in `crossplane xrd convert`

### DIFF
--- a/cmd/crossplane/xrd/convert.go
+++ b/cmd/crossplane/xrd/convert.go
@@ -19,16 +19,19 @@ package xrd
 import (
 	"bytes"
 	"path/filepath"
+	"slices"
 
 	"github.com/alecthomas/kong"
 	"github.com/spf13/afero"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/xcrd"
 
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1"
+	apiextensionsv2 "github.com/crossplane/crossplane/apis/v2/apiextensions/v2"
 
 	commonIO "github.com/crossplane/cli/v2/cmd/crossplane/convert/io"
 
@@ -72,8 +75,13 @@ func (c *convertCmd) Run(k *kong.Context) error {
 		return errors.Wrap(err, "cannot unmarshal XRD")
 	}
 
-	if xrd.GroupVersionKind() != apiextensionsv1.CompositeResourceDefinitionGroupVersionKind {
-		return errors.Errorf("input is not a %s; got %s", apiextensionsv1.CompositeResourceDefinitionGroupVersionKind, xrd.GroupVersionKind())
+	xrdGVKs := []schema.GroupVersionKind{
+		apiextensionsv1.CompositeResourceDefinitionGroupVersionKind,
+		apiextensionsv2.CompositeResourceDefinitionGroupVersionKind,
+	}
+
+	if !slices.Contains(xrdGVKs, xrd.GroupVersionKind()) {
+		return errors.Errorf("input is not one of %v; got %s", xrdGVKs, xrd.GroupVersionKind())
 	}
 
 	crds, err := toCRDs(xrd)


### PR DESCRIPTION
### Description of your changes

Previously, the `crossplane xrd convert` command accepted only v1 XRDs, even though the conversion logic works fine for v2 XRDs as well. Update the GVK check to include v2 so that the command works for either XRD version.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
