### PR TITLE
Expose host-native CLI binary as the default flake package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           sed -i "s|buildVersion = null;|buildVersion = \"$VERSION\";|" flake.nix
 
       - name: Build Artifacts
-        run: nix build --option warn-dirty false --print-build-logs
+        run: nix build .#release --option warn-dirty false --print-build-logs
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6

--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,8 @@
           build = import ./nix/build.nix { inherit pkgs self; };
         in
         {
-          default = build.release {
+          default = build.binary { inherit version; };
+          release = build.release {
             inherit
               version
               goPlatforms

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -87,6 +87,26 @@ let
 
 in
 {
+  # Host-native CLI binary. This is the default package, so nix build and nix
+  # run give you a binary for your own machine rather than the full release.
+  binary =
+    { version }:
+    goBinary {
+      inherit version;
+      pname = "crossplane";
+      subPackage = "cmd/crossplane";
+      platform = {
+        os = pkgs.stdenv.hostPlatform.parsed.kernel.name;
+        # Go and Nix disagree on architecture names.
+        arch =
+          {
+            "x86_64" = "amd64";
+            "aarch64" = "arm64";
+          }
+          .${pkgs.stdenv.hostPlatform.parsed.cpu.name};
+      };
+    };
+
   # Full release package with all artifacts.
   release =
     {


### PR DESCRIPTION
### Description of your changes

Fixes #125

The `default` package was the full release bundle: the CLI cross-compiled for all seven platforms, laid out under `bin/<os>_<arch>/crossplane`. This made `nix build` and `nix run` unhelpful for anyone consuming the CLI from another flake. `nix run` couldn't find a binary to run, and producing one binary meant a from-source build of all seven, six of which you'd throw away.

This PR makes `default` the host-native binary, built for the system Nix is running on, so `nix build` and `nix run` give you a single binary for your own machine. The multi-platform bundle moves to a new package named `release`.

The per-platform builder already existed to assemble the bundle, so `default` just wraps it for the host, deriving `GOOS` and `GOARCH` from `stdenv.hostPlatform`. The CI `build-artifacts` job now builds `.#release` explicitly so it still produces and uploads the full bundle. The `push-artifacts` app already referenced the `release` derivation directly, so the S3 push and promote flows are unaffected.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
