### PR TITLE
Decompress function runtime tarballs once when loading

### DIFF
--- a/cmd/crossplane/project/build.go
+++ b/cmd/crossplane/project/build.go
@@ -19,6 +19,7 @@ package project
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -123,11 +124,21 @@ func (c *buildCmd) Run(logger logging.Logger, sp terminal.SpinnerPrinter) error 
 		dependency.WithResolver(resolver),
 	)
 
+	// The builder may decompress function runtime tarballs into this directory;
+	// the built images read from it lazily, so we remove it only after the
+	// package has been written below.
+	tempDir, err := os.MkdirTemp("", "crossplane-build-")
+	if err != nil {
+		return errors.Wrap(err, "failed to create temporary build directory")
+	}
+	defer os.RemoveAll(tempDir) //nolint:errcheck // Best-effort cleanup of temporary files.
+
 	b := project.NewBuilder(
 		project.BuildWithMaxConcurrency(concurrency),
 		project.BuildWithFunctionIdentifier(functions.DefaultIdentifier),
 		project.BuildWithSchemaManager(schemaMgr),
 		project.BuildWithDependencyManager(depMgr),
+		project.BuildWithTempDir(tempDir),
 	)
 
 	var imgMap project.ImageTagMap

--- a/cmd/crossplane/project/run.go
+++ b/cmd/crossplane/project/run.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -176,11 +177,21 @@ func (c *runCmd) Run(logger logging.Logger, sp terminal.SpinnerPrinter) error { 
 		dependency.WithResolver(resolver),
 	)
 
+	// The builder may decompress function runtime tarballs into this directory;
+	// the built images read from it lazily, so we remove it only after they have
+	// been sideloaded below.
+	tempDir, err := os.MkdirTemp("", "crossplane-build-")
+	if err != nil {
+		return errors.Wrap(err, "failed to create temporary build directory")
+	}
+	defer os.RemoveAll(tempDir) //nolint:errcheck // Best-effort cleanup of temporary files.
+
 	b := project.NewBuilder(
 		project.BuildWithMaxConcurrency(concurrency),
 		project.BuildWithFunctionIdentifier(functions.DefaultIdentifier),
 		project.BuildWithSchemaManager(schemaMgr),
 		project.BuildWithDependencyManager(depMgr),
+		project.BuildWithTempDir(tempDir),
 	)
 
 	var (

--- a/cmd/crossplane/render/op/cmd.go
+++ b/cmd/crossplane/render/op/cmd.go
@@ -379,11 +379,21 @@ func (c *Cmd) loadFunctions(ctx context.Context, log logging.Logger, sp terminal
 		schemaRunner := runner.NewRealSchemaRunner(runner.WithImageConfig(proj.Spec.ImageConfigs))
 		schemaMgr := manager.New(schemasFS, generators, schemaRunner)
 
+		// The builder may decompress function runtime tarballs into this
+		// directory; the built images read from it lazily, so we remove it only
+		// after they have been written to the daemon below.
+		tempDir, err := os.MkdirTemp("", "crossplane-build-")
+		if err != nil {
+			return errors.Wrap(err, "failed to create temporary build directory")
+		}
+		defer os.RemoveAll(tempDir) //nolint:errcheck // Best-effort cleanup of temporary files.
+
 		b := project.NewBuilder(
 			project.BuildWithMaxConcurrency(c.MaxConcurrency),
 			project.BuildWithFunctionIdentifier(functions.DefaultIdentifier),
 			project.BuildWithSchemaManager(schemaMgr),
 			project.BuildWithDependencyManager(depMgr),
+			project.BuildWithTempDir(tempDir),
 		)
 
 		imgMap, err := b.Build(ctx, proj, projFS,

--- a/cmd/crossplane/render/xr/cmd.go
+++ b/cmd/crossplane/render/xr/cmd.go
@@ -448,11 +448,21 @@ func (c *Cmd) loadFunctions(ctx context.Context, log logging.Logger, sp terminal
 		schemaRunner := runner.NewRealSchemaRunner(runner.WithImageConfig(proj.Spec.ImageConfigs))
 		schemaMgr := manager.New(schemasFS, generators, schemaRunner)
 
+		// The builder may decompress function runtime tarballs into this
+		// directory; the built images read from it lazily, so we remove it only
+		// after they have been written to the daemon below.
+		tempDir, err := os.MkdirTemp("", "crossplane-build-")
+		if err != nil {
+			return errors.Wrap(err, "failed to create temporary build directory")
+		}
+		defer os.RemoveAll(tempDir) //nolint:errcheck // Best-effort cleanup of temporary files.
+
 		b := project.NewBuilder(
 			project.BuildWithMaxConcurrency(c.MaxConcurrency),
 			project.BuildWithFunctionIdentifier(functions.DefaultIdentifier),
 			project.BuildWithSchemaManager(schemaMgr),
 			project.BuildWithDependencyManager(depMgr),
+			project.BuildWithTempDir(tempDir),
 		)
 
 		imgMap, err := b.Build(ctx, proj, projFS,

--- a/internal/project/build.go
+++ b/internal/project/build.go
@@ -103,14 +103,12 @@ func BuildWithDependencyManager(m *dependency.Manager) BuilderOption {
 	}
 }
 
-// BuildWithTempDir sets the directory into which the builder decompresses
-// gzipped function runtime tarballs. The returned images may read from these
-// files lazily, so the caller owns the directory and must remove it only after
-// it has finished consuming the images.
+// BuildWithTempDir sets a directory the builder can use to hold temporary
+// files. The images returned from Build() may depend on this directory, so
+// callers should not remove it until they have finished consuming the images.
 //
-// If unset, the decompressed tarballs are written to the OS default temporary
-// directory and are not removed; callers that build gzipped tarball functions
-// should set this to a directory they delete.
+// If unset, the OS default temporary directory is to hold temporary files,
+// which are not cleaned up by the builder.
 func BuildWithTempDir(dir string) BuilderOption {
 	return func(b *Builder) {
 		b.tempDir = dir

--- a/internal/project/build.go
+++ b/internal/project/build.go
@@ -67,22 +67,13 @@ const (
 // ImageTagMap is a map of container image tags to images.
 type ImageTagMap map[name.Tag]v1.Image
 
-// Builder is able to build a project into a set of packages.
-type Builder interface {
-	// Build builds a project into a set of packages. It returns a map
-	// containing images that were built from the project. The returned map will
-	// always include one image with the ConfigurationTag, which is the
-	// configuration package built from the APIs found in the project.
-	Build(ctx context.Context, project *devv1alpha1.Project, projectFS afero.Fs, opts ...BuildOption) (ImageTagMap, error)
-}
-
-// BuilderOption configures a builder.
-type BuilderOption func(b *realBuilder)
+// BuilderOption configures a Builder.
+type BuilderOption func(b *Builder)
 
 // BuildWithFunctionIdentifier sets the function identifier that will be used to
 // find function builders for any functions in a project.
 func BuildWithFunctionIdentifier(i functions.Identifier) BuilderOption {
-	return func(b *realBuilder) {
+	return func(b *Builder) {
 		b.functionIdentifier = i
 	}
 }
@@ -90,7 +81,7 @@ func BuildWithFunctionIdentifier(i functions.Identifier) BuilderOption {
 // BuildWithMaxConcurrency sets the maximum concurrency for building embedded
 // functions.
 func BuildWithMaxConcurrency(n uint) BuilderOption {
-	return func(b *realBuilder) {
+	return func(b *Builder) {
 		b.maxConcurrency = n
 	}
 }
@@ -98,7 +89,7 @@ func BuildWithMaxConcurrency(n uint) BuilderOption {
 // BuildWithSchemaManager sets the schema manager that will be used to generate
 // language-specific schemas from XRDs before building functions.
 func BuildWithSchemaManager(m *manager.Manager) BuilderOption {
-	return func(b *realBuilder) {
+	return func(b *Builder) {
 		b.schemaManager = m
 	}
 }
@@ -107,8 +98,22 @@ func BuildWithSchemaManager(m *manager.Manager) BuilderOption {
 // ensure schemas are present for the project's declared dependencies before
 // building functions.
 func BuildWithDependencyManager(m *dependency.Manager) BuilderOption {
-	return func(b *realBuilder) {
+	return func(b *Builder) {
 		b.dependencyManager = m
+	}
+}
+
+// BuildWithTempDir sets the directory into which the builder decompresses
+// gzipped function runtime tarballs. The returned images may read from these
+// files lazily, so the caller owns the directory and must remove it only after
+// it has finished consuming the images.
+//
+// If unset, the decompressed tarballs are written to the OS default temporary
+// directory and are not removed; callers that build gzipped tarball functions
+// should set this to a directory they delete.
+func BuildWithTempDir(dir string) BuilderOption {
+	return func(b *Builder) {
+		b.tempDir = dir
 	}
 }
 
@@ -145,15 +150,26 @@ func BuildWithProjectBasePath(path string) BuildOption {
 	}
 }
 
-type realBuilder struct {
+// A Builder builds a project into a set of packages.
+//
+// The images Build returns may read lazily from temporary files on disk - for
+// example, when a function's runtime is supplied as a gzipped tarball that is
+// decompressed once during the build. These files are written to the temporary
+// directory set by BuildWithTempDir, which the caller owns and is responsible
+// for removing once it has finished consuming the returned images.
+type Builder struct {
 	functionIdentifier functions.Identifier
 	maxConcurrency     uint
 	schemaManager      *manager.Manager
 	dependencyManager  *dependency.Manager
+	tempDir            string
 }
 
-// Build implements the Builder interface.
-func (b *realBuilder) Build(ctx context.Context, project *devv1alpha1.Project, projectFS afero.Fs, opts ...BuildOption) (ImageTagMap, error) { //nolint:gocyclo // This is the main build orchestration.
+// Build builds a project into a set of packages. It returns a map containing
+// images that were built from the project. The returned map will always include
+// one image with the ConfigurationTag, which is the configuration package built
+// from the APIs found in the project.
+func (b *Builder) Build(ctx context.Context, project *devv1alpha1.Project, projectFS afero.Fs, opts ...BuildOption) (ImageTagMap, error) { //nolint:gocyclo // This is the main build orchestration.
 	o := &buildOptions{
 		log: logging.NewNopLogger(),
 	}
@@ -342,7 +358,7 @@ func resolveFunctions(project *devv1alpha1.Project, projectFS afero.Fs) ([]devv1
 }
 
 // buildFunctions builds the given list of embedded functions.
-func (b *realBuilder) buildFunctions(ctx context.Context, projectFS afero.Fs, project *devv1alpha1.Project, fns []devv1alpha1.Function, basePath string, eventCh async.EventChannel) (ImageTagMap, []xpmetav1.Dependency, error) {
+func (b *Builder) buildFunctions(ctx context.Context, projectFS afero.Fs, project *devv1alpha1.Project, fns []devv1alpha1.Function, basePath string, eventCh async.EventChannel) (ImageTagMap, []xpmetav1.Dependency, error) {
 	var (
 		imgMap = make(map[name.Tag]v1.Image)
 		imgMu  sync.Mutex
@@ -417,7 +433,7 @@ func (b *realBuilder) buildFunctions(ctx context.Context, projectFS afero.Fs, pr
 // buildFunction builds the package images for a single function. It resolves
 // the function's runtime images (either by building from source or by loading
 // a pre-built tarball) and then wraps each one with the package metadata.
-func (b *realBuilder) buildFunction(ctx context.Context, projectFS afero.Fs, project *devv1alpha1.Project, fn devv1alpha1.Function, basePath string) ([]v1.Image, error) {
+func (b *Builder) buildFunction(ctx context.Context, projectFS afero.Fs, project *devv1alpha1.Project, fn devv1alpha1.Function, basePath string) ([]v1.Image, error) {
 	fnName := fn.Name()
 	meta := &xpmetav1.Function{
 		TypeMeta: metav1.TypeMeta{
@@ -495,12 +511,12 @@ func (b *realBuilder) buildFunction(ctx context.Context, projectFS afero.Fs, pro
 // runtimeImages returns the per-architecture runtime images for a function. For
 // Directory-source functions this dispatches to the appropriate builder. For
 // Tarball-source functions it loads the supplied OCI tarball.
-func (b *realBuilder) runtimeImages(ctx context.Context, projectFS afero.Fs, project *devv1alpha1.Project, fn devv1alpha1.Function, basePath string) ([]v1.Image, error) {
+func (b *Builder) runtimeImages(ctx context.Context, projectFS afero.Fs, project *devv1alpha1.Project, fn devv1alpha1.Function, basePath string) ([]v1.Image, error) {
 	switch fn.Source {
 	case devv1alpha1.FunctionSourceDirectory:
 		return b.buildDirectoryRuntime(ctx, projectFS, project, fn.Directory, basePath)
 	case devv1alpha1.FunctionSourceTarball:
-		return loadTarballRuntime(projectFS, fn.Tarball, project.Spec.Architectures)
+		return loadTarballRuntime(projectFS, fn.Tarball, project.Spec.Architectures, b.tempDir)
 	default:
 		// Should be caught at validation time, but be defensive.
 		return nil, errors.Errorf("unsupported function source %q", fn.Source)
@@ -509,7 +525,7 @@ func (b *realBuilder) runtimeImages(ctx context.Context, projectFS afero.Fs, pro
 
 // buildDirectoryRuntime invokes the appropriate language builder to produce
 // runtime images from a function's source directory.
-func (b *realBuilder) buildDirectoryRuntime(ctx context.Context, projectFS afero.Fs, project *devv1alpha1.Project, dir *devv1alpha1.FunctionDirectory, basePath string) ([]v1.Image, error) {
+func (b *Builder) buildDirectoryRuntime(ctx context.Context, projectFS afero.Fs, project *devv1alpha1.Project, dir *devv1alpha1.FunctionDirectory, basePath string) ([]v1.Image, error) {
 	fnFS := afero.NewBasePathFs(projectFS, filepath.Join(project.Spec.Paths.Functions, dir.Name))
 
 	fnBasePath := ""
@@ -548,10 +564,10 @@ func (b *realBuilder) buildDirectoryRuntime(ctx context.Context, projectFS afero
 // `docker save`, Nix's dockerTools.buildImage, Bazel's oci_tarball,
 // `ko build --tarball`, etc. The gzipped variant is what most Nix image
 // builders emit by default.
-func loadTarballRuntime(projectFS afero.Fs, tb *devv1alpha1.FunctionTarball, architectures []string) ([]v1.Image, error) {
+func loadTarballRuntime(projectFS afero.Fs, tb *devv1alpha1.FunctionTarball, architectures []string, tempDir string) ([]v1.Image, error) {
 	images := make([]v1.Image, 0, len(architectures))
 	for _, arch := range architectures {
-		img, rel, err := loadRuntimeImage(projectFS, tb.PathPrefix, arch)
+		img, rel, err := loadRuntimeImage(projectFS, tb.PathPrefix, arch, tempDir)
 		if err != nil {
 			return nil, err
 		}
@@ -573,16 +589,6 @@ func loadTarballRuntime(projectFS afero.Fs, tb *devv1alpha1.FunctionTarball, arc
 	return images, nil
 }
 
-// fsOpener returns a tarball.Opener that reads a plain tar file from the given
-// filesystem. tarball.Image calls its opener multiple times - once for the
-// manifest and once per layer - so each call returns a fresh reader positioned
-// at the start of the file.
-func fsOpener(fsys afero.Fs, path string) tarball.Opener {
-	return func() (io.ReadCloser, error) {
-		return fsys.Open(path)
-	}
-}
-
 // loadRuntimeImage loads the runtime image for a single architecture. It tries
 // each candidate tarball in turn, preferring the plain .tar over the gzipped
 // .tar.gz, and loads the first one that exists. It returns the loaded image and
@@ -590,14 +596,16 @@ func fsOpener(fsys afero.Fs, path string) tarball.Opener {
 //
 // The tarballs are read through the project filesystem rather than from a real
 // on-disk path, so loading works the same whether the project FS is an
-// afero.BasePathFs or an in-memory FS in tests.
-func loadRuntimeImage(projectFS afero.Fs, prefix, arch string) (v1.Image, string, error) {
+// afero.BasePathFs or an in-memory FS in tests. A gzipped tarball is decompressed
+// once to a temporary file in tempDir; the image reads from that file lazily, so
+// the caller must keep the directory until it has finished consuming the image.
+func loadRuntimeImage(projectFS afero.Fs, prefix, arch, tempDir string) (v1.Image, string, error) {
 	candidates := []struct {
-		path   string
-		opener func(afero.Fs, string) tarball.Opener
+		path string
+		open func(fsys afero.Fs, path, tempDir string) (tarball.Opener, error)
 	}{
-		{path: fmt.Sprintf("%s-%s.tar", prefix, arch), opener: fsOpener},
-		{path: fmt.Sprintf("%s-%s.tar.gz", prefix, arch), opener: gzipOpener},
+		{path: fmt.Sprintf("%s-%s.tar", prefix, arch), open: fsOpener},
+		{path: fmt.Sprintf("%s-%s.tar.gz", prefix, arch), open: gzipOpener},
 	}
 
 	tried := make([]string, 0, len(candidates))
@@ -612,7 +620,12 @@ func loadRuntimeImage(projectFS afero.Fs, prefix, arch string) (v1.Image, string
 			continue
 		}
 
-		img, err := tarball.Image(c.opener(projectFS, c.path), nil)
+		opener, err := c.open(projectFS, c.path, tempDir)
+		if err != nil {
+			return nil, c.path, errors.Wrapf(err, "failed to open runtime image for architecture %q from %q", arch, c.path)
+		}
+
+		img, err := tarball.Image(opener, nil)
 		if err != nil {
 			return nil, c.path, errors.Wrapf(err, "failed to load runtime image for architecture %q from %q", arch, c.path)
 		}
@@ -622,36 +635,40 @@ func loadRuntimeImage(projectFS afero.Fs, prefix, arch string) (v1.Image, string
 	return nil, tried[0], errors.Errorf("no runtime image found for architecture %q: looked for %v", arch, tried)
 }
 
-// gzipOpener returns a tarball.Opener that reads a gzipped tar file from the
-// given filesystem. Like fsOpener it can be called repeatedly; each call
-// returns a fresh decompressing reader that reads the file from the beginning.
-func gzipOpener(fsys afero.Fs, path string) tarball.Opener {
-	return func() (io.ReadCloser, error) {
-		f, err := fsys.Open(path)
-		if err != nil {
-			return nil, err
-		}
-		gz, err := gzip.NewReader(f)
-		if err != nil {
-			_ = f.Close()
-			return nil, err
-		}
-		return gzipReadCloser{Reader: gz, file: f}, nil
+// fsOpener returns a tarball.Opener that reads the plain tar at path directly
+// from fsys. Each call returns a fresh reader at the start of the file, as
+// tarball.Image requires. It needs no temporary directory; tempDir lets it share
+// a signature with gzipOpener so loadRuntimeImage can treat both uniformly.
+func fsOpener(fsys afero.Fs, path, _ string) (tarball.Opener, error) {
+	return func() (io.ReadCloser, error) { return fsys.Open(path) }, nil
+}
+
+// gzipOpener decompresses the gzipped tar at path on fsys once into tempDir and
+// returns a tarball.Opener that reads the decompressed file.
+//
+// tarball.Image calls the opener repeatedly - once for the manifest, once for
+// the config, and once per layer - so decompressing once up front avoids
+// re-running gzip over the whole image for every call.
+func gzipOpener(fsys afero.Fs, path, tempDir string) (tarball.Opener, error) {
+	f, err := fsys.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open %q", path)
 	}
-}
+	defer f.Close() //nolint:errcheck // Read-only file we copy from below.
 
-// gzipReadCloser ties together a gzip.Reader and the underlying file so that
-// closing the gzip reader also closes the file.
-type gzipReadCloser struct {
-	*gzip.Reader
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read gzip header of %q", path)
+	}
+	defer gz.Close() //nolint:errcheck // Read-only reader.
 
-	file afero.File
-}
-
-// Close closes both the gzip reader and the underlying file, joining any errors
-// so neither failure is lost.
-func (g gzipReadCloser) Close() error {
-	return errors.Join(g.Reader.Close(), g.file.Close())
+	tmpPath, err := writeTempTarball(tempDir, gz)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to decompress %q", path)
+	}
+	return func() (io.ReadCloser, error) {
+		return os.Open(tmpPath) //nolint:gosec // tmpPath is a file we created in our own temp directory.
+	}, nil
 }
 
 func collectResources(toFS afero.Fs, fromFS afero.Fs, gvks []string, exclude []string) error {
@@ -758,9 +775,12 @@ func fnMetaFromProject(proj *devv1alpha1.Project, fnName string) metav1.ObjectMe
 	return *meta
 }
 
-// NewBuilder returns a new project builder.
-func NewBuilder(opts ...BuilderOption) Builder {
-	b := &realBuilder{
+// NewBuilder returns a new project builder. Callers that build functions whose
+// runtime is supplied as a gzipped tarball should set BuildWithTempDir and
+// remove the directory once they have finished consuming the images returned by
+// Build.
+func NewBuilder(opts ...BuilderOption) *Builder {
+	b := &Builder{
 		functionIdentifier: functions.DefaultIdentifier,
 		maxConcurrency:     8,
 	}
@@ -770,4 +790,30 @@ func NewBuilder(opts ...BuilderOption) Builder {
 	}
 
 	return b
+}
+
+// writeTempTarball copies r to a new temporary file in dir and returns its path.
+// If dir is empty the OS default temporary directory is used. The caller owns
+// the file and is responsible for removing it (or the directory containing it).
+func writeTempTarball(dir string, r io.Reader) (string, error) {
+	f, err := os.CreateTemp(dir, "runtime-*.tar")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create temporary file")
+	}
+	// Close the file on the error paths below. The happy path closes it
+	// explicitly to capture the flush error, leaving this a harmless second
+	// close.
+	defer f.Close() //nolint:errcheck // See comment above.
+
+	// The tarball is a trusted, locally-built image, so we don't bound the
+	// decompressed size.
+	if _, err := io.Copy(f, r); err != nil {
+		_ = os.Remove(f.Name())
+		return "", errors.Wrap(err, "failed to copy tarball")
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", errors.Wrap(err, "failed to flush temporary file")
+	}
+	return f.Name(), nil
 }

--- a/internal/project/build_test.go
+++ b/internal/project/build_test.go
@@ -19,6 +19,8 @@ package project
 import (
 	"compress/gzip"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -27,8 +29,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/spf13/afero"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -258,9 +260,11 @@ func TestBuilderDependsOn(t *testing.T) {
 	}
 	proj.Default()
 
-	imgMap, err := NewBuilder(
+	b := NewBuilder(
 		BuildWithFunctionIdentifier(functions.FakeIdentifier),
-	).Build(t.Context(), proj, projFS)
+	)
+
+	imgMap, err := b.Build(t.Context(), proj, projFS)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -414,7 +418,9 @@ func TestBuilderBuildExplicitFunctions(t *testing.T) {
 	}
 	proj.Default()
 
-	imgMap, err := NewBuilder(BuildWithFunctionIdentifier(functions.FakeIdentifier)).Build(t.Context(), proj, projFS)
+	b := NewBuilder(BuildWithFunctionIdentifier(functions.FakeIdentifier))
+
+	imgMap, err := b.Build(t.Context(), proj, projFS)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -464,7 +470,9 @@ func TestBuilderBuildTarballFunction(t *testing.T) {
 	}
 	proj.Default()
 
-	imgMap, err := NewBuilder(BuildWithFunctionIdentifier(functions.FakeIdentifier)).Build(t.Context(), proj, projFS)
+	b := NewBuilder(BuildWithFunctionIdentifier(functions.FakeIdentifier))
+
+	imgMap, err := b.Build(t.Context(), proj, projFS)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -582,7 +590,7 @@ func TestLoadTarballRuntime(t *testing.T) {
 			}
 
 			tb := &devv1alpha1.FunctionTarball{Name: "fn", PathPrefix: "fn"}
-			got, err := loadTarballRuntime(projFS, tb, tc.args.archs)
+			got, err := loadTarballRuntime(projFS, tb, tc.args.archs, t.TempDir())
 
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("loadTarballRuntime(...): -want error, +got error:\n%s", diff)
@@ -591,6 +599,73 @@ func TestLoadTarballRuntime(t *testing.T) {
 				t.Errorf("loadTarballRuntime(...) architectures: -want, +got:\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestLoadRuntimeImageGzip checks that loading a multi-layer image from a gzipped
+// tarball yields the same image as the equivalent plain tarball - including when
+// every layer is read, which happens lazily after loading from the decompressed
+// temporary file - and that the tarball is decompressed into the builder's temp
+// directory.
+func TestLoadRuntimeImageGzip(t *testing.T) {
+	t.Parallel()
+
+	projFS := afero.NewMemMapFs()
+	// The same multi-layer image under both a plain and a gzipped path, so the
+	// two must load to identical digests.
+	img := runtimeImageForArch(t, "amd64")
+	writeRuntimeTarImage(t, projFS, "plain-amd64.tar", "amd64", img)
+	writeRuntimeTarImage(t, projFS, "gz-amd64.tar.gz", "amd64", img)
+
+	tempDir := t.TempDir()
+
+	plain, _, err := loadRuntimeImage(projFS, "plain", "amd64", tempDir)
+	if err != nil {
+		t.Fatalf("loadRuntimeImage(plain): %v", err)
+	}
+	gz, _, err := loadRuntimeImage(projFS, "gz", "amd64", tempDir)
+	if err != nil {
+		t.Fatalf("loadRuntimeImage(gz): %v", err)
+	}
+
+	// digestReadingLayers computes the image digest and reads every layer's
+	// content. Reading the layers forces the per-layer opener calls that, for
+	// the gzipped image, are served from the decompressed temporary file.
+	digestReadingLayers := func(img v1.Image) v1.Hash {
+		t.Helper()
+		d, err := img.Digest()
+		if err != nil {
+			t.Fatalf("Digest(): %v", err)
+		}
+		layers, err := img.Layers()
+		if err != nil {
+			t.Fatalf("Layers(): %v", err)
+		}
+		for _, l := range layers {
+			rc, err := l.Compressed()
+			if err != nil {
+				t.Fatalf("Compressed(): %v", err)
+			}
+			if _, err := io.Copy(io.Discard, rc); err != nil {
+				t.Fatalf("reading layer: %v", err)
+			}
+			_ = rc.Close()
+		}
+		return d
+	}
+
+	if diff := cmp.Diff(digestReadingLayers(plain), digestReadingLayers(gz)); diff != "" {
+		t.Errorf("gzipped and plain tarballs produced different digests: -plain, +gz:\n%s", diff)
+	}
+
+	// The gzipped tarball should have been decompressed into the builder's temp
+	// directory; the plain tar is read directly and leaves nothing behind.
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("ReadDir(%q): %v", tempDir, err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected exactly one decompressed tarball in temp dir, got %d: %v", len(entries), entries)
 	}
 }
 
@@ -609,16 +684,43 @@ func archsOf(t *testing.T, imgs []v1.Image) []string {
 	return archs
 }
 
-// writeRuntimeTar writes a single-platform Docker-style image tarball to the
-// given path on fsys containing an empty image whose config records the given
-// architecture. If the path ends with ".tar.gz" the tarball is gzipped.
-func writeRuntimeTar(t *testing.T, fsys afero.Fs, path, arch string) {
+// runtimeImageForArch returns a multi-layer single-platform image whose config
+// records the given architecture. The layers mean loading it from a tarball
+// exercises the per-layer lazy opener calls tarball.Image makes.
+func runtimeImageForArch(t *testing.T, arch string) v1.Image {
 	t.Helper()
 
-	img, err := mutate.ConfigFile(empty.Image, &v1.ConfigFile{OS: "linux", Architecture: arch})
+	img, err := random.Image(256, 4)
 	if err != nil {
 		t.Fatal(err)
 	}
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg = cfg.DeepCopy()
+	cfg.OS, cfg.Architecture = "linux", arch
+	img, err = mutate.ConfigFile(img, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return img
+}
+
+// writeRuntimeTar writes a single-platform Docker-style image tarball recording
+// the given architecture to path on fsys. If the path ends with ".tar.gz" the
+// tarball is gzipped.
+func writeRuntimeTar(t *testing.T, fsys afero.Fs, path, arch string) {
+	t.Helper()
+	writeRuntimeTarImage(t, fsys, path, arch, runtimeImageForArch(t, arch))
+}
+
+// writeRuntimeTarImage writes img as a single-platform Docker-style image
+// tarball to path on fsys. If the path ends with ".tar.gz" the tarball is
+// gzipped.
+func writeRuntimeTarImage(t *testing.T, fsys afero.Fs, path, arch string, img v1.Image) {
+	t.Helper()
+
 	tag, err := name.NewTag("crossplane.io/test:" + arch)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
### Description of your changes

#24 added support for gzipped function runtime image tarballs by streaming each one through `gzip.NewReader` directly into go-containerregistry's `tarball.Image`.

go-containerregistry calls the `tarball.Opener` it's given once per layer, plus once each for the manifest and config. Because the gzip opener re-opened and re-decompressed the whole file from the start on every call, loading a single image decompressed it once per layer.

My project uses Nix's `dockerTools`, which emits one layer per store path, so a typical function image has ~50 layers and was fully gunzipped ~54 times. Computing the image digest then re-reads every layer again. With functions built concurrently, a project with a dozen multi-arch functions spent over ten minutes pegging every core in this loop.

This PR decompresses each gzipped tarball once into a temporary file and serves every opener call from that plain tar. The temporary files back the returned images lazily, so they must outlive `Build`; the builder now creates them under a per-build temporary directory and exposes a `Close` method that removes the directory once the caller has finished consuming the images. `NewBuilder` returns the concrete `*realBuilder` so callers can `defer Close`, and the build, run, and render entry points do so after they have written, sideloaded, or loaded the images.

On a project with twelve functions built for amd64 and arm64, loading all twenty-four images drops from over ten minutes to roughly eighty seconds.

This follows on from #21 and #24, which introduced pre-built and gzipped function runtime tarball support respectively.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
