### PR TITLE
feat: add --json-schema flag to xrd convert

### DIFF
--- a/cmd/crossplane/xpkg/get_crds.go
+++ b/cmd/crossplane/xpkg/get_crds.go
@@ -17,7 +17,6 @@ limitations under the License.
 package xpkg
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,7 +25,6 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/spf13/afero"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	runtimeSchema "k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
@@ -184,48 +182,29 @@ func (c *getCRDsCmd) outputPath(flatName, group, version, kind, ext string) stri
 // shared schema mutations from internal/schemas/generator for YAML language
 // server compatibility (additionalProperties: false on object types, etc.).
 func (c *getCRDsCmd) writeJSONSchemas(k *kong.Context, crds []*extv1.CustomResourceDefinition) error {
-	count := 0
+	schemas, err := generator.CRDsToJSONSchemas(crds)
+	if err != nil {
+		return err
+	}
 
-	for _, crd := range crds {
-		group := crd.Spec.Group
-		kind := crd.Spec.Names.Kind
+	for _, s := range schemas {
+		flatName := fmt.Sprintf("%s_%s_%s", s.Group, s.Version, strings.ToLower(s.Kind))
+		outPath := c.outputPath(flatName, s.Group, s.Version, s.Kind, ".json")
 
-		for _, ver := range crd.Spec.Versions {
-			if ver.Schema == nil || ver.Schema.OpenAPIV3Schema == nil {
-				continue
-			}
+		if err := c.fs.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+			return errors.Wrapf(err, "cannot create directory for %q", outPath)
+		}
 
-			gvk := runtimeSchema.GroupVersionKind{Group: group, Version: ver.Name, Kind: kind}
-			schema, err := generator.ToJSONSchema(ver.Schema.OpenAPIV3Schema, gvk)
-			if err != nil {
-				return errors.Wrapf(err, "cannot convert schema for %s/%s %s", group, ver.Name, kind)
-			}
+		if err := afero.WriteFile(c.fs, outPath, s.Data, 0o644); err != nil {
+			return errors.Wrapf(err, "cannot write JSON Schema to %q", outPath)
+		}
 
-			data, err := json.MarshalIndent(schema, "", "  ")
-			if err != nil {
-				return errors.Wrapf(err, "cannot marshal JSON Schema for %s/%s %s", group, ver.Name, kind)
-			}
-
-			flatName := fmt.Sprintf("%s_%s_%s", group, ver.Name, strings.ToLower(kind))
-			outPath := c.outputPath(flatName, group, ver.Name, kind, ".json")
-
-			if err := c.fs.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
-				return errors.Wrapf(err, "cannot create directory for %q", outPath)
-			}
-
-			if err := afero.WriteFile(c.fs, outPath, data, 0o644); err != nil {
-				return errors.Wrapf(err, "cannot write JSON Schema to %q", outPath)
-			}
-
-			if _, err := fmt.Fprintf(k.Stdout, "wrote %s\n", outPath); err != nil {
-				return errors.Wrap(err, errWriteOutput)
-			}
-
-			count++
+		if _, err := fmt.Fprintf(k.Stdout, "wrote %s\n", outPath); err != nil {
+			return errors.Wrap(err, errWriteOutput)
 		}
 	}
 
-	if _, err := fmt.Fprintf(k.Stdout, "Total %d JSON Schemas written to %s\n", count, c.OutputDir); err != nil {
+	if _, err := fmt.Fprintf(k.Stdout, "Total %d JSON Schemas written to %s\n", len(schemas), c.OutputDir); err != nil {
 		return errors.Wrap(err, errWriteOutput)
 	}
 

--- a/cmd/crossplane/xrd/convert.go
+++ b/cmd/crossplane/xrd/convert.go
@@ -18,8 +18,10 @@ package xrd
 
 import (
 	"bytes"
+	"fmt"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/alecthomas/kong"
 	"github.com/spf13/afero"
@@ -34,12 +36,18 @@ import (
 	apiextensionsv2 "github.com/crossplane/crossplane/apis/v2/apiextensions/v2"
 
 	commonIO "github.com/crossplane/cli/v2/cmd/crossplane/convert/io"
+	"github.com/crossplane/cli/v2/internal/schemas/generator"
 
 	_ "embed"
 )
 
 //go:embed help/convert.md
 var convertHelp string
+
+type convertOutput struct {
+	output string
+	data   []byte
+}
 
 type convertCmd struct {
 	// Arguments.
@@ -50,6 +58,9 @@ type convertCmd struct {
 	// YAML stream.
 	OutputFile string `help:"The file to write the generated CRD YAML to. Legacy XRDs produce a multi-doc YAML stream (XR CRD + Claim CRD)." placeholder:"PATH" predictor:"file"      short:"o"   type:"path"  xor:"output"`
 	OutputDir  string `help:"A directory to write the generated CRDs to. Each CRD gets a separate file named after the CRD."                 placeholder:"DIR"  predictor:"directory" type:"path" xor:"output"`
+
+	// Format flags.
+	JSONSchema bool `help:"Write JSON Schema files instead of CRDs. Useful for YAML language server integration." name:"json-schema"`
 
 	fs afero.Fs
 }
@@ -89,67 +100,85 @@ func (c *convertCmd) Run(k *kong.Context) error {
 		return errors.Wrapf(err, "cannot derive CRDs from XRD %q", xrd.GetName())
 	}
 
-	switch {
-	case c.OutputDir != "":
-		if err := c.fs.MkdirAll(c.OutputDir, 0o755); err != nil {
-			return errors.Wrapf(err, "cannot create output directory %q", c.OutputDir)
-		}
-
-		for _, crd := range crds {
-			path := filepath.Join(c.OutputDir, crd.GetName()+".yaml")
-			if err := c.writeFile(path, []*extv1.CustomResourceDefinition{crd}); err != nil {
-				return err
-			}
-		}
-
-		return nil
-
-	case c.OutputFile != "":
-		return c.writeFile(c.OutputFile, crds)
-
-	default:
-		data, err := marshalCRDs(crds)
-		if err != nil {
-			return err
-		}
-
-		if _, err := k.Stdout.Write(data); err != nil {
-			return errors.Wrap(err, "cannot write output")
-		}
-
-		return nil
+	var outputs []convertOutput
+	if c.JSONSchema {
+		outputs, err = toJSONSchemaOutputs(crds)
+	} else {
+		outputs, err = toCRDOutputs(crds)
 	}
-}
-
-// writeFile marshals the given CRDs to a multi-doc YAML stream and writes it to path.
-func (c *convertCmd) writeFile(path string, crds []*extv1.CustomResourceDefinition) error {
-	data, err := marshalCRDs(crds)
 	if err != nil {
 		return err
 	}
 
-	if err := afero.WriteFile(c.fs, path, data, 0o644); err != nil {
-		return errors.Wrapf(err, "cannot write output file %q", path)
-	}
-
-	return nil
+	return c.writeOutputs(k, outputs)
 }
 
-// marshalCRDs returns the multi-doc YAML stream for the given CRDs.
-func marshalCRDs(crds []*extv1.CustomResourceDefinition) ([]byte, error) {
-	var buf bytes.Buffer
-
+func toCRDOutputs(crds []*extv1.CustomResourceDefinition) ([]convertOutput, error) {
+	outputs := make([]convertOutput, 0, len(crds))
 	for _, crd := range crds {
 		b, err := yaml.Marshal(crd)
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot marshal CRD %q", crd.GetName())
 		}
 
-		buf.WriteString("---\n")
-		buf.Write(b)
+		outputs = append(outputs, convertOutput{
+			output: crd.GetName() + ".yaml",
+			data:   append([]byte("---\n"), b...),
+		})
+	}
+	return outputs, nil
+}
+
+func toJSONSchemaOutputs(crds []*extv1.CustomResourceDefinition) ([]convertOutput, error) {
+	schemas, err := generator.CRDsToJSONSchemas(crds)
+	if err != nil {
+		return nil, err
 	}
 
-	return buf.Bytes(), nil
+	outputs := make([]convertOutput, 0, len(schemas))
+	for _, s := range schemas {
+		outputs = append(outputs, convertOutput{
+			output: fmt.Sprintf("%s_%s_%s.json", s.Group, s.Version, strings.ToLower(s.Kind)),
+			data:   s.Data,
+		})
+	}
+	return outputs, nil
+}
+
+func (c *convertCmd) writeOutputs(k *kong.Context, outputs []convertOutput) error {
+	if c.OutputDir != "" {
+		if err := c.fs.MkdirAll(c.OutputDir, 0o755); err != nil {
+			return errors.Wrapf(err, "cannot create output directory %q", c.OutputDir)
+		}
+
+		for _, o := range outputs {
+			path := filepath.Join(c.OutputDir, o.output)
+			if err := afero.WriteFile(c.fs, path, o.data, 0o644); err != nil {
+				return errors.Wrapf(err, "cannot write output file %q", path)
+			}
+		}
+
+		return nil
+	}
+
+	var buf bytes.Buffer
+	for _, o := range outputs {
+		buf.Write(o.data)
+	}
+
+	if c.OutputFile != "" {
+		if err := afero.WriteFile(c.fs, c.OutputFile, buf.Bytes(), 0o644); err != nil {
+			return errors.Wrapf(err, "cannot write output file %q", c.OutputFile)
+		}
+
+		return nil
+	}
+
+	if _, err := k.Stdout.Write(buf.Bytes()); err != nil {
+		return errors.Wrap(err, "cannot write output")
+	}
+
+	return nil
 }
 
 // toCRDs converts a Crossplane XRD into the Kubernetes CRDs that describe

--- a/cmd/crossplane/xrd/convert.go
+++ b/cmd/crossplane/xrd/convert.go
@@ -161,6 +161,10 @@ func (c *convertCmd) writeOutputs(k *kong.Context, outputs []convertOutput) erro
 		return nil
 	}
 
+	if c.JSONSchema && len(outputs) > 1 {
+		return errors.Errorf("cannot write %d JSON Schemas to a single output; use --output-dir to write one file per schema", len(outputs))
+	}
+
 	var buf bytes.Buffer
 	for _, o := range outputs {
 		buf.Write(o.data)

--- a/cmd/crossplane/xrd/convert.go
+++ b/cmd/crossplane/xrd/convert.go
@@ -56,11 +56,9 @@ type convertCmd struct {
 	// Output flags. OutputFile and OutputDir are mutually exclusive; when
 	// neither is set the converted CRDs are emitted on stdout as a multi-doc
 	// YAML stream.
-	OutputFile string `help:"The file to write the generated CRD YAML to. Legacy XRDs produce a multi-doc YAML stream (XR CRD + Claim CRD)." placeholder:"PATH" predictor:"file"      short:"o"   type:"path"  xor:"output"`
-	OutputDir  string `help:"A directory to write the generated CRDs to. Each CRD gets a separate file named after the CRD."                 placeholder:"DIR"  predictor:"directory" type:"path" xor:"output"`
-
-	// Format flags.
-	JSONSchema bool `help:"Write JSON Schema files instead of CRDs. Useful for YAML language server integration." name:"json-schema"`
+	OutputFile string `help:"The file to write the generated CRD YAML to. Legacy XRDs produce a multi-doc YAML stream (XR CRD + Claim CRD)." placeholder:"PATH"    predictor:"file"                                                                             short:"o"   type:"path"  xor:"output"`
+	OutputDir  string `help:"A directory to write the generated CRDs to. Each CRD gets a separate file named after the CRD."                 placeholder:"DIR"     predictor:"directory"                                                                        type:"path" xor:"output"`
+	Format     string `default:"crd"                                                                                                         enum:"crd,jsonschema" help:"Write JSON Schema files instead of CRDs. Useful for YAML language server integration."`
 
 	fs afero.Fs
 }
@@ -101,10 +99,10 @@ func (c *convertCmd) Run(k *kong.Context) error {
 	}
 
 	var outputs []convertOutput
-	if c.JSONSchema {
-		outputs, err = toJSONSchemaOutputs(crds)
-	} else {
+	if c.Format == "crd" {
 		outputs, err = toCRDOutputs(crds)
+	} else {
+		outputs, err = toJSONSchemaOutputs(crds)
 	}
 	if err != nil {
 		return err
@@ -161,7 +159,7 @@ func (c *convertCmd) writeOutputs(k *kong.Context, outputs []convertOutput) erro
 		return nil
 	}
 
-	if c.JSONSchema && len(outputs) > 1 {
+	if c.Format == "jsonschema" && len(outputs) > 1 {
 		return errors.Errorf("cannot write %d JSON Schemas to a single output; use --output-dir to write one file per schema", len(outputs))
 	}
 

--- a/cmd/crossplane/xrd/convert_test.go
+++ b/cmd/crossplane/xrd/convert_test.go
@@ -123,17 +123,17 @@ func TestConvertJSONSchema(t *testing.T) {
 	}{
 		"Stdout": {
 			reason:    "With no output flags, JSON Schema should be written to stdout.",
-			cmd:       convertCmd{JSONSchema: true},
+			cmd:       convertCmd{Format: "jsonschema"},
 			wantStdio: true,
 		},
 		"OutputFile": {
 			reason:   "With -o, JSON Schema should be written to the specified file.",
-			cmd:      convertCmd{JSONSchema: true, OutputFile: "/out/schema.json"},
+			cmd:      convertCmd{Format: "jsonschema", OutputFile: "/out/schema.json"},
 			wantFile: "/out/schema.json",
 		},
 		"OutputDir": {
 			reason:   "With --output-dir, JSON Schema should be written as a named file in the directory.",
-			cmd:      convertCmd{JSONSchema: true, OutputDir: "/schemas"},
+			cmd:      convertCmd{Format: "jsonschema", OutputDir: "/schemas"},
 			wantFile: filepath.Join("/schemas", wantFile),
 		},
 	}
@@ -202,7 +202,7 @@ func TestConvertJSONSchemaMultiSchema(t *testing.T) {
 
 	// OutputDir should succeed and write each schema to its own file.
 	fs := afero.NewMemMapFs()
-	cmd := convertCmd{JSONSchema: true, OutputDir: "/schemas", fs: fs}
+	cmd := convertCmd{Format: "jsonschema", OutputDir: "/schemas", fs: fs}
 	k := newKongContext(t)
 	if err := cmd.writeOutputs(k, outputs); err != nil {
 		t.Fatalf("writeOutputs(OutputDir): unexpected error: %v", err)
@@ -214,13 +214,13 @@ func TestConvertJSONSchemaMultiSchema(t *testing.T) {
 	}
 
 	// Stdout and OutputFile should reject multiple schemas.
-	cmd = convertCmd{JSONSchema: true, fs: afero.NewMemMapFs()}
+	cmd = convertCmd{Format: "jsonschema", fs: afero.NewMemMapFs()}
 	k = newKongContext(t)
 	if err := cmd.writeOutputs(k, outputs); err == nil {
 		t.Error("expected error writing multiple JSON Schemas to stdout")
 	}
 
-	cmd = convertCmd{JSONSchema: true, OutputFile: "/out.json", fs: afero.NewMemMapFs()}
+	cmd = convertCmd{Format: "jsonschema", OutputFile: "/out.json", fs: afero.NewMemMapFs()}
 	k = newKongContext(t)
 	if err := cmd.writeOutputs(k, outputs); err == nil {
 		t.Error("expected error writing multiple JSON Schemas to single file")

--- a/cmd/crossplane/xrd/convert_test.go
+++ b/cmd/crossplane/xrd/convert_test.go
@@ -266,4 +266,3 @@ func minimalXRD(scope apiextensionsv1.CompositeResourceScope, claimNames *extv1.
 		},
 	}
 }
-

--- a/cmd/crossplane/xrd/convert_test.go
+++ b/cmd/crossplane/xrd/convert_test.go
@@ -17,9 +17,15 @@ limitations under the License.
 package xrd
 
 import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
 	"testing"
 
+	"github.com/alecthomas/kong"
 	"github.com/google/go-cmp/cmp"
+	"github.com/invopop/jsonschema"
+	"github.com/spf13/afero"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -100,6 +106,88 @@ func TestToCRDs(t *testing.T) {
 	}
 }
 
+func TestConvertJSONSchema(t *testing.T) {
+	xrd := minimalXRD(apiextensionsv1.CompositeResourceScopeNamespaced, nil)
+	crds, err := toCRDs(xrd)
+	if err != nil {
+		t.Fatalf("toCRDs(): unexpected error: %v", err)
+	}
+
+	wantFile := "example.org_v1alpha1_xtestapp.json"
+
+	cases := map[string]struct {
+		reason    string
+		cmd       convertCmd
+		wantFile  string
+		wantStdio bool
+	}{
+		"Stdout": {
+			reason:    "With no output flags, JSON Schema should be written to stdout.",
+			cmd:       convertCmd{JSONSchema: true},
+			wantStdio: true,
+		},
+		"OutputFile": {
+			reason:   "With -o, JSON Schema should be written to the specified file.",
+			cmd:      convertCmd{JSONSchema: true, OutputFile: "/out/schema.json"},
+			wantFile: "/out/schema.json",
+		},
+		"OutputDir": {
+			reason:   "With --output-dir, JSON Schema should be written as a named file in the directory.",
+			cmd:      convertCmd{JSONSchema: true, OutputDir: "/schemas"},
+			wantFile: filepath.Join("/schemas", wantFile),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			tc.cmd.fs = fs
+
+			buf := &bytes.Buffer{}
+			app, err := kong.New(&struct{}{})
+			if err != nil {
+				t.Fatalf("cannot create kong app: %v", err)
+			}
+			k, err := app.Parse([]string{})
+			if err != nil {
+				t.Fatalf("cannot parse kong: %v", err)
+			}
+			k.Stdout = buf
+
+			outputs, err := toJSONSchemaOutputs(crds)
+			if err != nil {
+				t.Fatalf("\n%s\ntoJSONSchemaOutputs(): unexpected error: %v", tc.reason, err)
+			}
+
+			if err := tc.cmd.writeOutputs(k, outputs); err != nil {
+				t.Fatalf("\n%s\nwriteOutputs(): unexpected error: %v", tc.reason, err)
+			}
+
+			var raw []byte
+			if tc.wantStdio {
+				if buf.Len() == 0 {
+					t.Fatalf("\n%s\nexpected stdout output, got nothing", tc.reason)
+				}
+				raw = buf.Bytes()
+			} else {
+				raw, err = afero.ReadFile(fs, tc.wantFile)
+				if err != nil {
+					t.Fatalf("\n%s\nexpected file %s to exist: %v", tc.reason, tc.wantFile, err)
+				}
+			}
+
+			var s jsonschema.Schema
+			if err := json.Unmarshal(raw, &s); err != nil {
+				t.Errorf("\n%s\noutput is not valid JSON Schema: %v", tc.reason, err)
+			}
+
+			if s.ID == "" {
+				t.Errorf("\n%s\nexpected JSON Schema $id to be set", tc.reason)
+			}
+		})
+	}
+}
+
 // minimalXRD returns a minimal valid XRD with the given scope and (optional)
 // claim names. All other fields are populated with defaults sufficient to
 // satisfy xcrd.ForCompositeResource / xcrd.ForCompositeResourceClaim.
@@ -125,3 +213,4 @@ func minimalXRD(scope apiextensionsv1.CompositeResourceScope, claimNames *extv1.
 		},
 	}
 }
+

--- a/cmd/crossplane/xrd/convert_test.go
+++ b/cmd/crossplane/xrd/convert_test.go
@@ -143,16 +143,8 @@ func TestConvertJSONSchema(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			tc.cmd.fs = fs
 
-			buf := &bytes.Buffer{}
-			app, err := kong.New(&struct{}{})
-			if err != nil {
-				t.Fatalf("cannot create kong app: %v", err)
-			}
-			k, err := app.Parse([]string{})
-			if err != nil {
-				t.Fatalf("cannot parse kong: %v", err)
-			}
-			k.Stdout = buf
+			k := newKongContext(t)
+			buf := k.Stdout.(*bytes.Buffer)
 
 			outputs, err := toJSONSchemaOutputs(crds)
 			if err != nil {
@@ -186,6 +178,67 @@ func TestConvertJSONSchema(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConvertJSONSchemaMultiSchema(t *testing.T) {
+	claimNames := &extv1.CustomResourceDefinitionNames{
+		Kind:   "TestApp",
+		Plural: "testapps",
+	}
+	xrd := minimalXRD(apiextensionsv1.CompositeResourceScopeLegacyCluster, claimNames)
+	crds, err := toCRDs(xrd)
+	if err != nil {
+		t.Fatalf("toCRDs(): unexpected error: %v", err)
+	}
+
+	outputs, err := toJSONSchemaOutputs(crds)
+	if err != nil {
+		t.Fatalf("toJSONSchemaOutputs(): unexpected error: %v", err)
+	}
+
+	if len(outputs) < 2 {
+		t.Fatalf("expected at least 2 outputs for legacy XRD with Claim, got %d", len(outputs))
+	}
+
+	// OutputDir should succeed and write each schema to its own file.
+	fs := afero.NewMemMapFs()
+	cmd := convertCmd{JSONSchema: true, OutputDir: "/schemas", fs: fs}
+	k := newKongContext(t)
+	if err := cmd.writeOutputs(k, outputs); err != nil {
+		t.Fatalf("writeOutputs(OutputDir): unexpected error: %v", err)
+	}
+	for _, o := range outputs {
+		if _, err := afero.ReadFile(fs, filepath.Join("/schemas", o.output)); err != nil {
+			t.Errorf("expected file %s to exist: %v", o.output, err)
+		}
+	}
+
+	// Stdout and OutputFile should reject multiple schemas.
+	cmd = convertCmd{JSONSchema: true, fs: afero.NewMemMapFs()}
+	k = newKongContext(t)
+	if err := cmd.writeOutputs(k, outputs); err == nil {
+		t.Error("expected error writing multiple JSON Schemas to stdout")
+	}
+
+	cmd = convertCmd{JSONSchema: true, OutputFile: "/out.json", fs: afero.NewMemMapFs()}
+	k = newKongContext(t)
+	if err := cmd.writeOutputs(k, outputs); err == nil {
+		t.Error("expected error writing multiple JSON Schemas to single file")
+	}
+}
+
+func newKongContext(t *testing.T) *kong.Context {
+	t.Helper()
+	app, err := kong.New(&struct{}{})
+	if err != nil {
+		t.Fatalf("cannot create kong app: %v", err)
+	}
+	k, err := app.Parse([]string{})
+	if err != nil {
+		t.Fatalf("cannot parse kong: %v", err)
+	}
+	k.Stdout = &bytes.Buffer{}
+	return k
 }
 
 // minimalXRD returns a minimal valid XRD with the given scope and (optional)

--- a/cmd/crossplane/xrd/help/convert.md
+++ b/cmd/crossplane/xrd/help/convert.md
@@ -36,3 +36,15 @@ Read the XRD from stdin:
 ```shell
 cat xrd.yaml | crossplane xrd convert -
 ```
+
+Convert an XRD to JSON Schema and print to stdout:
+
+```shell
+crossplane xrd convert xrd.yaml --json-schema
+```
+
+Convert an XRD to JSON Schema files in a directory:
+
+```shell
+crossplane xrd convert xrd.yaml --json-schema --output-dir ./schemas/
+```

--- a/cmd/crossplane/xrd/help/convert.md
+++ b/cmd/crossplane/xrd/help/convert.md
@@ -40,11 +40,11 @@ cat xrd.yaml | crossplane xrd convert -
 Convert an XRD to JSON Schema and print to stdout:
 
 ```shell
-crossplane xrd convert xrd.yaml --json-schema
+crossplane xrd convert xrd.yaml --format=jsonschema
 ```
 
 Convert an XRD to JSON Schema files in a directory:
 
 ```shell
-crossplane xrd convert xrd.yaml --json-schema --output-dir ./schemas/
+crossplane xrd convert xrd.yaml --format=jsonschema --output-dir ./schemas/
 ```

--- a/internal/schemas/generator/json.go
+++ b/internal/schemas/generator/json.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/invopop/jsonschema"
 	"github.com/spf13/afero"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	runtimeSchema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -36,6 +37,14 @@ import (
 	devv1alpha1 "github.com/crossplane/cli/v2/apis/dev/v1alpha1"
 	"github.com/crossplane/cli/v2/internal/schemas/runner"
 )
+
+// CRDJSONSchema holds a marshaled JSON Schema derived from a single CRD version.
+type CRDJSONSchema struct {
+	Data    []byte
+	Group   string
+	Version string
+	Kind    string
+}
 
 type jsonGenerator struct{}
 
@@ -114,6 +123,43 @@ func ToJSONSchema(s any, gvk runtimeSchema.GroupVersionKind) (*jsonschema.Schema
 	}
 
 	return &conv, nil
+}
+
+// CRDsToJSONSchemas converts CRD OpenAPI v3 schemas to marshaled JSON Schemas.
+func CRDsToJSONSchemas(crds []*extv1.CustomResourceDefinition) ([]CRDJSONSchema, error) {
+	var results []CRDJSONSchema
+
+	for _, crd := range crds {
+		group := crd.Spec.Group
+		kind := crd.Spec.Names.Kind
+
+		for _, ver := range crd.Spec.Versions {
+			if ver.Schema == nil || ver.Schema.OpenAPIV3Schema == nil {
+				continue
+			}
+
+			gvk := runtimeSchema.GroupVersionKind{Group: group, Version: ver.Name, Kind: kind}
+			s, err := ToJSONSchema(ver.Schema.OpenAPIV3Schema, gvk)
+			if err != nil {
+				return nil, errors.Wrapf(err, "cannot convert schema for %s/%s %s", group, ver.Name, kind)
+			}
+
+			data, err := json.MarshalIndent(s, "", "  ")
+			if err != nil {
+				return nil, errors.Wrapf(err, "cannot marshal JSON Schema for %s/%s %s", group, ver.Name, kind)
+			}
+
+			data = append(data, '\n')
+			results = append(results, CRDJSONSchema{
+				Data:    data,
+				Group:   group,
+				Version: ver.Name,
+				Kind:    kind,
+			})
+		}
+	}
+
+	return results, nil
 }
 
 // mutateJSONSchema applies YAML language server compatibility fixes to a JSON


### PR DESCRIPTION
### Description of your changes

Add `--json-schema` flag to `xrd convert` subcommand, similarly as what `xpkg get-crds` subcommand already provides.

Refactor the common logic to avoid duplication.

Fixes #141 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
