### PR TITLE
fix(render): annotate functions when reusing an existing network

### DIFF
--- a/cmd/crossplane/render/engine.go
+++ b/cmd/crossplane/render/engine.go
@@ -42,12 +42,15 @@ type Engine interface {
 	// can reach the render engine. It may mutate fns.
 	//
 	// Setup may be called more than once on the same engine to integrate
-	// additional functions into an environment created by a prior call. The
-	// first call initializes the environment (e.g. creates the Docker
-	// network) and returns a real cleanup; subsequent calls integrate the
-	// supplied fns and return a no-op cleanup. The single real cleanup must
-	// be called when rendering is done; callers can safely defer every
-	// returned cleanup in LIFO order without coordinating which one is real.
+	// additional functions into an environment created by a prior call.
+	// Only the call that creates a new environment returns a real cleanup;
+	// calls that integrate fns into an environment that already exists
+	// (because a prior Setup call established it, or because the engine was
+	// pre-configured to use an externally-managed environment) return a
+	// no-op cleanup, as do calls on engines with nothing to clean up. The
+	// real cleanup, if any, must be called when rendering is done; callers
+	// can safely defer every returned cleanup in LIFO order without
+	// coordinating which one is real.
 	Setup(ctx context.Context, fns []pkgv1.Function) (cleanup func(), err error)
 
 	// Render executes the render request and returns the response.

--- a/cmd/crossplane/render/engine.go
+++ b/cmd/crossplane/render/engine.go
@@ -39,8 +39,15 @@ type Engine interface {
 
 	// Setup performs engine-specific pre-render preparation, such as
 	// creating Docker networks and annotating functions so their containers
-	// can reach the render engine. It may mutate fns. The returned cleanup
-	// function must be called when rendering is done.
+	// can reach the render engine. It may mutate fns.
+	//
+	// Setup may be called more than once on the same engine to integrate
+	// additional functions into an environment created by a prior call. The
+	// first call initializes the environment (e.g. creates the Docker
+	// network) and returns a real cleanup; subsequent calls integrate the
+	// supplied fns and return a no-op cleanup. The single real cleanup must
+	// be called when rendering is done; callers can safely defer every
+	// returned cleanup in LIFO order without coordinating which one is real.
 	Setup(ctx context.Context, fns []pkgv1.Function) (cleanup func(), err error)
 
 	// Render executes the render request and returns the response.

--- a/cmd/crossplane/render/engine_docker.go
+++ b/cmd/crossplane/render/engine_docker.go
@@ -77,20 +77,26 @@ func (e *dockerRenderEngine) CheckContextSupport() error {
 	return nil
 }
 
-// Setup creates a temporary Docker network, records its name so the render
-// container joins it, and annotates the supplied functions so their
-// containers also join it. The returned cleanup function removes the
-// network.
+// Setup wires the supplied functions into the Docker network the render
+// container joins. On the first call with an unset e.network, it creates a
+// temporary network, records its name, annotates fns to join it, and returns
+// a cleanup that removes the network. On any subsequent call — or on the
+// first call when e.network was already set via --crossplane-docker-network —
+// it only annotates fns with the existing network and returns a no-op
+// cleanup, leaving network ownership to whoever created it. fns whose
+// runtime-docker-network annotation is already set are left untouched.
 func (e *dockerRenderEngine) Setup(ctx context.Context, fns []pkgv1.Function) (func(), error) {
-	var networkID, networkName string
-
 	if e.network != "" {
-		// e.network was pre-configured, we don't own the network, so there is nothing to clean up.
+		// Either the user pre-configured the network via the --crossplane-docker-network flag
+		// (we don't own it), or a prior Setup call on this engine already created one (the
+		// real cleanup belongs to that first call). In both cases we still need to annotate
+		// the supplied fns so their containers join the network — injectNetworkAnnotation
+		// won't overwrite an annotation a fn already carries.
+		injectNetworkAnnotation(fns, e.network)
 		return func() {}, nil
 	}
 
-	var err error
-	networkID, networkName, err = createRenderNetwork(ctx)
+	networkID, networkName, err := createRenderNetwork(ctx)
 	if err != nil {
 		return func() {}, errors.Wrap(err, "cannot create Docker network for rendering")
 	}

--- a/cmd/crossplane/render/engine_docker_test.go
+++ b/cmd/crossplane/render/engine_docker_test.go
@@ -216,137 +216,132 @@ func TestDockerRenderEngineRender(t *testing.T) {
 
 func TestDockerRenderEngineSetup(t *testing.T) {
 	// These cases all exercise the early-return branch of Setup — where
-	// e.network is already non-empty (set by a prior Setup call on the same
-	// engine, or by NewEngineFromFlags from the --crossplane-docker-network
-	// flag). The branch must annotate the supplied functions so their
-	// containers join the network, while never creating a second network and
-	// always returning a no-op cleanup. The create-new-network branch is not
-	// covered here because it depends on a live Docker daemon; the tests for
-	// the broader render commands exercise it integration-style.
+	// e.network is already non-empty, either because NewEngineFromFlags
+	// populated it from --crossplane-docker-network or because a prior Setup
+	// call on the same engine stored its created network there. The branch
+	// must annotate the supplied functions so their containers join the
+	// network, never create a second network, and always return a no-op
+	// cleanup. The create-new-network branch is not covered here because it
+	// depends on a live Docker daemon; the broader render command tests
+	// exercise it integration-style.
+	//
+	// The MultiBatchAnnotatesAdditionalFunctions case simulates the
+	// in-process multi-composition use case from crossplane/cli#96: a
+	// downstream tool (crossplane-diff) calls Setup once per Composition it
+	// encounters. Pre-seeding e.network stands in for the prior Setup call
+	// that would have created the network, keeping the test hermetic.
 	const presetNetwork = "preset-net"
 
-	type want struct {
-		fns           []pkgv1.Function
-		cleanupNotNil bool
+	// batch holds a single Setup invocation: the fns to pass in and the
+	// expected fn state after Setup returns. Multi-call cases provide more
+	// than one batch; the runner invokes Setup once per batch in order.
+	type batch struct {
+		fns     []pkgv1.Function
+		wantFns []pkgv1.Function
 	}
 
 	cases := map[string]struct {
-		reason string
-		engine *dockerRenderEngine
-		fns    []pkgv1.Function
-		want   want
+		reason  string
+		engine  *dockerRenderEngine
+		batches []batch
 	}{
 		"AnnotatesFunctionsWhenNetworkPreset": {
 			reason: "When e.network is set, Setup must inject the network annotation on every fn that does not already carry one, so that crossplane-diff-style multi-batch callers can re-Setup to add new fns to the same network.",
 			engine: &dockerRenderEngine{network: presetNetwork, log: logging.NewNopLogger()},
-			fns: []pkgv1.Function{
-				functionWithAnnotations(nil),
-				functionWithAnnotations(nil),
-			},
-			want: want{
+			batches: []batch{{
 				fns: []pkgv1.Function{
+					functionWithAnnotations(nil),
+					functionWithAnnotations(nil),
+				},
+				wantFns: []pkgv1.Function{
 					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: presetNetwork}),
 					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: presetNetwork}),
 				},
-				cleanupNotNil: true,
-			},
+			}},
 		},
 		"PreservesUserSetFunctionAnnotation": {
 			reason: "If a fn already carries a runtime-docker-network annotation, Setup must not overwrite it. This preserves the don't-overwrite contract from PR #65 for users who pin their fns to a specific network.",
 			engine: &dockerRenderEngine{network: presetNetwork, log: logging.NewNopLogger()},
-			fns: []pkgv1.Function{
-				functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: "user-pinned-net"}),
-			},
-			want: want{
+			batches: []batch{{
 				fns: []pkgv1.Function{
 					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: "user-pinned-net"}),
 				},
-				cleanupNotNil: true,
-			},
+				wantFns: []pkgv1.Function{
+					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: "user-pinned-net"}),
+				},
+			}},
+		},
+		"NilFunctionsList": {
+			reason: "A nil fns slice is a boundary case: Setup must succeed without panicking on the nil-map guard inside injectNetworkAnnotation.",
+			engine: &dockerRenderEngine{network: presetNetwork, log: logging.NewNopLogger()},
+			batches: []batch{{
+				fns:     nil,
+				wantFns: nil,
+			}},
 		},
 		"EmptyFunctionsList": {
-			reason: "An empty fns slice is the trivial boundary case: Setup must succeed and return a non-nil (no-op) cleanup. No panic on nil annotations map.",
+			reason: "An empty (non-nil) fns slice is the other boundary: Setup must succeed, the slice stays empty, and no spurious entries appear.",
 			engine: &dockerRenderEngine{network: presetNetwork, log: logging.NewNopLogger()},
-			fns:    nil,
-			want: want{
-				fns:           nil,
-				cleanupNotNil: true,
+			batches: []batch{{
+				fns:     []pkgv1.Function{},
+				wantFns: []pkgv1.Function{},
+			}},
+		},
+		"MultiBatchAnnotatesAdditionalFunctions": {
+			reason: "Two consecutive Setup calls on the same engine — the crossplane/cli#96 in-process multi-composition pattern — must annotate every batch with the same network. Each call returns a no-op cleanup that is safe to defer in LIFO order.",
+			engine: &dockerRenderEngine{network: presetNetwork, log: logging.NewNopLogger()},
+			batches: []batch{
+				{
+					fns: []pkgv1.Function{
+						functionWithAnnotations(nil),
+						functionWithAnnotations(nil),
+					},
+					wantFns: []pkgv1.Function{
+						functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: presetNetwork}),
+						functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: presetNetwork}),
+					},
+				},
+				{
+					fns: []pkgv1.Function{
+						functionWithAnnotations(nil),
+					},
+					wantFns: []pkgv1.Function{
+						functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: presetNetwork}),
+					},
+				},
 			},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			cleanup, err := tc.engine.Setup(context.Background(), tc.fns)
-			if err != nil {
-				t.Fatalf("\n%s\nSetup(...): unexpected error: %v", tc.reason, err)
-			}
-			if tc.want.cleanupNotNil && cleanup == nil {
-				t.Fatalf("\n%s\nSetup(...): cleanup is nil, want non-nil", tc.reason)
-			}
-			// Cleanup must not panic. For the early-return branch it is a no-op,
-			// but exercising the call documents the contract.
-			cleanup()
+			cleanups := make([]func(), 0, len(tc.batches))
+			for i, b := range tc.batches {
+				cleanup, err := tc.engine.Setup(context.Background(), b.fns)
+				if err != nil {
+					t.Fatalf("\n%s\nSetup(batch %d): unexpected error: %v", tc.reason, i, err)
+				}
+				if cleanup == nil {
+					t.Fatalf("\n%s\nSetup(batch %d): cleanup is nil, want non-nil", tc.reason, i)
+				}
+				cleanups = append(cleanups, cleanup)
 
-			if diff := cmp.Diff(tc.want.fns, tc.fns); diff != "" {
-				t.Errorf("\n%s\nSetup(...): fns -want, +got:\n%s", tc.reason, diff)
+				if diff := cmp.Diff(b.wantFns, b.fns); diff != "" {
+					t.Errorf("\n%s\nSetup(batch %d): fns -want, +got:\n%s", tc.reason, i, diff)
+				}
+			}
+
+			// Defer-LIFO: all cleanups in this test are no-ops (we pre-seed
+			// e.network, so no call took the create-network branch). Calling
+			// them must not panic.
+			for i := len(cleanups) - 1; i >= 0; i-- {
+				cleanups[i]()
 			}
 
 			if tc.engine.network != presetNetwork {
 				t.Errorf("\n%s\nSetup(...): e.network mutated from %q to %q (early-return branch must not change it)", tc.reason, presetNetwork, tc.engine.network)
 			}
 		})
-	}
-}
-
-func TestDockerRenderEngineSetupMultiBatch(t *testing.T) {
-	// Simulates the in-process multi-composition use case from
-	// crossplane/cli#96: a downstream tool (crossplane-diff) calls Setup once
-	// per Composition it encounters. The first call creates the network; each
-	// subsequent call must annotate its new fns with the same network so all
-	// function containers can reach each other and the render container.
-	//
-	// We seed e.network to "first-batch-net" to stand in for the prior Setup
-	// call that would have created the network. This keeps the test
-	// hermetic (no Docker daemon required) while still exercising the
-	// multi-batch path that motivated this change.
-	const network = "first-batch-net"
-
-	e := &dockerRenderEngine{network: network, log: logging.NewNopLogger()}
-
-	batch1 := []pkgv1.Function{functionWithAnnotations(nil), functionWithAnnotations(nil)}
-	batch2 := []pkgv1.Function{functionWithAnnotations(nil)}
-
-	cleanup1, err := e.Setup(context.Background(), batch1)
-	if err != nil {
-		t.Fatalf("Setup(batch1): unexpected error: %v", err)
-	}
-	cleanup2, err := e.Setup(context.Background(), batch2)
-	if err != nil {
-		t.Fatalf("Setup(batch2): unexpected error: %v", err)
-	}
-
-	// Both cleanups are no-ops here (e.network was pre-set, so neither Setup
-	// call created a network). Calling them in defer-LIFO order must not
-	// panic. In a real caller, the very first Setup — the one that actually
-	// created the network — would return the real cleanup; we cannot exercise
-	// that path without Docker.
-	cleanup2()
-	cleanup1()
-
-	wantBatch1 := []pkgv1.Function{
-		functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: network}),
-		functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: network}),
-	}
-	wantBatch2 := []pkgv1.Function{
-		functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: network}),
-	}
-
-	if diff := cmp.Diff(wantBatch1, batch1); diff != "" {
-		t.Errorf("Setup(batch1): fns -want, +got:\n%s", diff)
-	}
-	if diff := cmp.Diff(wantBatch2, batch2); diff != "" {
-		t.Errorf("Setup(batch2): fns -want, +got:\n%s", diff)
 	}
 }
 

--- a/cmd/crossplane/render/engine_docker_test.go
+++ b/cmd/crossplane/render/engine_docker_test.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 
+	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
+
 	"github.com/crossplane/cli/v2/internal/docker"
 	renderv1alpha1 "github.com/crossplane/cli/v2/proto/render/v1alpha1"
 )
@@ -209,6 +211,142 @@ func TestDockerRenderEngineRender(t *testing.T) {
 				t.Errorf("\n%s\nRender(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
+	}
+}
+
+func TestDockerRenderEngineSetup(t *testing.T) {
+	// These cases all exercise the early-return branch of Setup — where
+	// e.network is already non-empty (set by a prior Setup call on the same
+	// engine, or by NewEngineFromFlags from the --crossplane-docker-network
+	// flag). The branch must annotate the supplied functions so their
+	// containers join the network, while never creating a second network and
+	// always returning a no-op cleanup. The create-new-network branch is not
+	// covered here because it depends on a live Docker daemon; the tests for
+	// the broader render commands exercise it integration-style.
+	const presetNetwork = "preset-net"
+
+	type want struct {
+		fns           []pkgv1.Function
+		cleanupNotNil bool
+	}
+
+	cases := map[string]struct {
+		reason string
+		engine *dockerRenderEngine
+		fns    []pkgv1.Function
+		want   want
+	}{
+		"AnnotatesFunctionsWhenNetworkPreset": {
+			reason: "When e.network is set, Setup must inject the network annotation on every fn that does not already carry one, so that crossplane-diff-style multi-batch callers can re-Setup to add new fns to the same network.",
+			engine: &dockerRenderEngine{network: presetNetwork, log: logging.NewNopLogger()},
+			fns: []pkgv1.Function{
+				functionWithAnnotations(nil),
+				functionWithAnnotations(nil),
+			},
+			want: want{
+				fns: []pkgv1.Function{
+					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: presetNetwork}),
+					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: presetNetwork}),
+				},
+				cleanupNotNil: true,
+			},
+		},
+		"PreservesUserSetFunctionAnnotation": {
+			reason: "If a fn already carries a runtime-docker-network annotation, Setup must not overwrite it. This preserves the don't-overwrite contract from PR #65 for users who pin their fns to a specific network.",
+			engine: &dockerRenderEngine{network: presetNetwork, log: logging.NewNopLogger()},
+			fns: []pkgv1.Function{
+				functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: "user-pinned-net"}),
+			},
+			want: want{
+				fns: []pkgv1.Function{
+					functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: "user-pinned-net"}),
+				},
+				cleanupNotNil: true,
+			},
+		},
+		"EmptyFunctionsList": {
+			reason: "An empty fns slice is the trivial boundary case: Setup must succeed and return a non-nil (no-op) cleanup. No panic on nil annotations map.",
+			engine: &dockerRenderEngine{network: presetNetwork, log: logging.NewNopLogger()},
+			fns:    nil,
+			want: want{
+				fns:           nil,
+				cleanupNotNil: true,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cleanup, err := tc.engine.Setup(context.Background(), tc.fns)
+			if err != nil {
+				t.Fatalf("\n%s\nSetup(...): unexpected error: %v", tc.reason, err)
+			}
+			if tc.want.cleanupNotNil && cleanup == nil {
+				t.Fatalf("\n%s\nSetup(...): cleanup is nil, want non-nil", tc.reason)
+			}
+			// Cleanup must not panic. For the early-return branch it is a no-op,
+			// but exercising the call documents the contract.
+			cleanup()
+
+			if diff := cmp.Diff(tc.want.fns, tc.fns); diff != "" {
+				t.Errorf("\n%s\nSetup(...): fns -want, +got:\n%s", tc.reason, diff)
+			}
+
+			if tc.engine.network != presetNetwork {
+				t.Errorf("\n%s\nSetup(...): e.network mutated from %q to %q (early-return branch must not change it)", tc.reason, presetNetwork, tc.engine.network)
+			}
+		})
+	}
+}
+
+func TestDockerRenderEngineSetupMultiBatch(t *testing.T) {
+	// Simulates the in-process multi-composition use case from
+	// crossplane/cli#96: a downstream tool (crossplane-diff) calls Setup once
+	// per Composition it encounters. The first call creates the network; each
+	// subsequent call must annotate its new fns with the same network so all
+	// function containers can reach each other and the render container.
+	//
+	// We seed e.network to "first-batch-net" to stand in for the prior Setup
+	// call that would have created the network. This keeps the test
+	// hermetic (no Docker daemon required) while still exercising the
+	// multi-batch path that motivated this change.
+	const network = "first-batch-net"
+
+	e := &dockerRenderEngine{network: network, log: logging.NewNopLogger()}
+
+	batch1 := []pkgv1.Function{functionWithAnnotations(nil), functionWithAnnotations(nil)}
+	batch2 := []pkgv1.Function{functionWithAnnotations(nil)}
+
+	cleanup1, err := e.Setup(context.Background(), batch1)
+	if err != nil {
+		t.Fatalf("Setup(batch1): unexpected error: %v", err)
+	}
+	cleanup2, err := e.Setup(context.Background(), batch2)
+	if err != nil {
+		t.Fatalf("Setup(batch2): unexpected error: %v", err)
+	}
+
+	// Both cleanups are no-ops here (e.network was pre-set, so neither Setup
+	// call created a network). Calling them in defer-LIFO order must not
+	// panic. In a real caller, the very first Setup — the one that actually
+	// created the network — would return the real cleanup; we cannot exercise
+	// that path without Docker.
+	cleanup2()
+	cleanup1()
+
+	wantBatch1 := []pkgv1.Function{
+		functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: network}),
+		functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: network}),
+	}
+	wantBatch2 := []pkgv1.Function{
+		functionWithAnnotations(map[string]string{AnnotationKeyRuntimeDockerNetwork: network}),
+	}
+
+	if diff := cmp.Diff(wantBatch1, batch1); diff != "" {
+		t.Errorf("Setup(batch1): fns -want, +got:\n%s", diff)
+	}
+	if diff := cmp.Diff(wantBatch2, batch2); diff != "" {
+		t.Errorf("Setup(batch2): fns -want, +got:\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

`dockerRenderEngine.Setup` short-circuits when `e.network` is already set — either pre-configured via `--crossplane-docker-network` or set by a prior `Setup` call on the same engine. Until now that short-circuit skipped `injectNetworkAnnotation`, leaving the supplied fns un-annotated and their containers unreachable from the render container.

This PR annotates fns in that branch too. `injectNetworkAnnotation` already declines to overwrite a fn that carries its own `runtime-docker-network` annotation (PR #65), so users who pin fns to a specific network are unaffected.

The result is that `Setup` is idempotent for in-process multi-batch rendering: a downstream tool like [crossplane-contrib/crossplane-diff](https://github.com/crossplane-contrib/crossplane-diff) that calls `Render` across many compositions in a single process can call `Setup` once per composition, and every batch's fns end up on the same network. The first call returns the real cleanup; subsequent calls return no-ops, so `defer cleanup()` per batch is safe in LIFO order. Discussion of the alternative (a new `AddFunctions` interface method) is in the issue #96 thread; the short version is that the uniform-per-batch caller shape Option A provides is what callers actually want, and Option B's interface delta doesn't earn its keep.

**Production change** is one line of new behavior in the early-return branch of `dockerRenderEngine.Setup`, plus a small variable-declaration tidy. The `Engine` interface signature is unchanged; `localRenderEngine`, `MockEngine`, and all callers in `xr` / `op` are untouched.

**Tests** are additive: `TestDockerRenderEngineSetup` covers the early-return branch directly (annotates on preset network, preserves user-set annotation, empty-fns boundary), and `TestDockerRenderEngineSetupMultiBatch` exercises the in-process multi-batch scenario from #96. The create-new-network branch is unchanged and continues to be exercised by the existing integration-style command tests.

**Docstrings** on both `Engine.Setup` (interface) and `dockerRenderEngine.Setup` (impl) are updated to describe the multi-call semantics so callers can rely on them.

Fixes #96

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review. <!-- Nix not available locally; relying on CI. `go test ./...` and `golangci-lint run` are clean. -->
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ <!-- Bug fix, no user-visible doc surface. -->
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ <!-- Defer to maintainers on backport policy. -->

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet