### PR TITLE
feat: add CI workflow to auto-update CLI docs (#31)

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,83 @@
+name: Update CLI Docs
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  update-docs:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
+        with:
+          name: crossplane
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build CLI
+        run: |
+          nix build .#crossplane --print-build-logs
+          cp result/bin/crossplane /tmp/crossplane
+
+      - name: Generate Docs
+        run: |
+          mkdir -p generated-docs
+          /tmp/crossplane generate-docs -o generated-docs/command-reference.md
+
+      - name: Checkout Docs
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: crossplane/docs
+          token: ${{ secrets.DOCS_WRITE_TOKEN }}
+          path: docs
+
+      - name: Determine Target Directory
+        id: target
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+            DIR_NAME="${VERSION#v}"
+            echo "dir=content/cli/${DIR_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "dir=content/cli/master" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update Docs
+        run: |
+          mkdir -p docs/${{ steps.target.outputs.dir }}
+          cp generated-docs/command-reference.md docs/${{ steps.target.outputs.dir }}/command-reference.md
+          cd docs
+          if ! git diff --quiet; then
+            echo "docs-changed=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Create Pull Request
+        if: env.docs-changed == 'true'
+        uses: peter-evans/create-pull-request@204220e584d39b97d07e8e00693fe658ea76b09d # v7
+        with:
+          path: docs
+          token: ${{ secrets.DOCS_WRITE_TOKEN }}
+          commit-message: "docs(cli): auto-update command reference"
+          title: "docs(cli): auto-update command reference for ${{ steps.target.outputs.dir }}"
+          body: |
+            Auto-generated CLI command reference update.
+
+            Generated from: `${{ github.sha }}`
+            Trigger: `${{ github.event_name }} ${{ github.ref }}`
+          branch: auto/update-cli-docs
+          delete-branch: true

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -2,8 +2,6 @@ name: Update CLI Docs
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 
@@ -12,6 +10,9 @@ permissions:
 
 jobs:
   update-docs:
+    concurrency:
+      group: update-cli-docs
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write
@@ -49,20 +50,16 @@ jobs:
       - name: Determine Target Directory
         id: target
         run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            VERSION="${GITHUB_REF#refs/tags/}"
-            DIR_NAME="${VERSION#v}"
-            echo "dir=content/cli/${DIR_NAME}" >> "$GITHUB_OUTPUT"
-          else
-            echo "dir=content/cli/master" >> "$GITHUB_OUTPUT"
-          fi
+          VERSION="${GITHUB_REF#refs/tags/}"
+          MINOR_VERSION="${VERSION%.*}"
+          echo "dir=content/cli/${MINOR_VERSION#v}" >> "$GITHUB_OUTPUT"
 
       - name: Update Docs
         run: |
           mkdir -p docs/${{ steps.target.outputs.dir }}
           cp generated-docs/command-reference.md docs/${{ steps.target.outputs.dir }}/command-reference.md
           cd docs
-          if ! git diff --quiet; then
+          if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
             echo "docs-changed=true" >> "$GITHUB_ENV"
           fi
 

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -12,7 +12,7 @@ jobs:
   update-docs:
     concurrency:
       group: update-cli-docs
-      cancel-in-progress: true
+      cancel-in-progress: false
     permissions:
       contents: write
       pull-requests: write
@@ -55,9 +55,11 @@ jobs:
           echo "dir=content/cli/${MINOR_VERSION#v}" >> "$GITHUB_OUTPUT"
 
       - name: Update Docs
+        env:
+          TARGET_DIR: ${{ steps.target.outputs.dir }}
         run: |
-          mkdir -p docs/${{ steps.target.outputs.dir }}
-          cp generated-docs/command-reference.md docs/${{ steps.target.outputs.dir }}/command-reference.md
+          mkdir -p "docs/${TARGET_DIR}"
+          cp generated-docs/command-reference.md "docs/${TARGET_DIR}/command-reference.md"
           cd docs
           if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
             echo "docs-changed=true" >> "$GITHUB_ENV"


### PR DESCRIPTION
Closes #31

Adds a GitHub Actions workflow that automatically updates CLI command reference documentation in the crossplane/docs repository.

## Changes
- New `.github/workflows/update-docs.yml` workflow triggered on push to main and on release tags
- Builds the CLI via Nix, runs `crossplane generate-docs`, then creates a PR to crossplane/docs via `peter-evans/create-pull-request`

## How to Test
Requires a `DOCS_WRITE_TOKEN` secret with write access to crossplane/docs repo. The workflow will create a PR to that repo when triggered on push to main or a new tag.