### PR TITLE
Fix two potential race conditions in project-related code

### DIFF
--- a/internal/project/controlplane/controlplane.go
+++ b/internal/project/controlplane/controlplane.go
@@ -34,7 +34,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -278,7 +280,9 @@ func EnsureLocalDevControlPlane(ctx context.Context, opts ...Option) (DevControl
 		return nil, errors.Wrap(err, "cannot get rest config")
 	}
 
-	cl, err := client.New(restConfig, client.Options{})
+	cl, err := client.New(restConfig, client.Options{
+		Scheme: newScheme(),
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot construct control plane client")
 	}
@@ -332,6 +336,12 @@ func EnsureLocalDevControlPlane(ctx context.Context, opts ...Option) (DevControl
 		registryContainerID: cid,
 		registryHostname:    regName + ":5000",
 	}, nil
+}
+
+func newScheme() *runtime.Scheme {
+	sch := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(sch)
+	return sch
 }
 
 // TeardownLocalDevControlPlane tears down a local dev control plane by name.

--- a/internal/schemas/manager/manager.go
+++ b/internal/schemas/manager/manager.go
@@ -80,6 +80,7 @@ func (m *Manager) Generate(ctx context.Context, source Source) (map[string]afero
 		return nil, err
 	}
 
+	var schemasMu sync.Mutex
 	schemas := make(map[string]afero.Fs)
 	eg, egCtx := errgroup.WithContext(ctx)
 	sourceType := source.Type()
@@ -101,7 +102,9 @@ func (m *Manager) Generate(ctx context.Context, source Source) (map[string]afero
 			}
 
 			if schemaFS != nil {
+				schemasMu.Lock()
 				schemas[gen.Language()] = schemaFS
+				schemasMu.Unlock()
 			}
 
 			return nil


### PR DESCRIPTION
### Description of your changes

These two potential race conditions in project-related code were reported in `up` but are present here as well and could cause crashes due to concurrent map accesses:

1. Go schema generation calls some OpenAPI code from Kubernetes libraries that uses the global scheme.Scheme. Our dev control plane clients also used scheme.Scheme (the default), so if we called AddToScheme at an inopportune time it could race. Fix this by using a fresh scheme for the dev control plane client.
2. We generate schemas for all languages in parallel, which could result in concurrent map writes in the schema generation code. Fix this by adding a mutex to protect the map of schemas.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
