### PR TITLE
projects: Skip empty documents when applying init and extra resources

### DIFF
--- a/internal/project/install.go
+++ b/internal/project/install.go
@@ -276,8 +276,13 @@ func packageHasHealthyConditions(pkg xpkgv1.PackageRevision) bool {
 // ApplyResources installs arbitrary resources to the target control plane.
 func ApplyResources(ctx context.Context, cl client.Client, resources []runtime.RawExtension) error {
 	for _, raw := range resources {
+		// Skip empty documents. A YAML manifest can contain documents that hold
+		// no resource — e.g. a leading comment block before the first "---"
+		// separator, or "---\n---" between two resources — which unmarshal to an
+		// empty RawExtension. kubectl skips these; do the same rather than
+		// rejecting an otherwise valid manifest.
 		if len(raw.Raw) == 0 {
-			return errors.New("encountered an invalid or empty raw resource")
+			continue
 		}
 
 		obj := &unstructured.Unstructured{}

--- a/internal/project/install_test.go
+++ b/internal/project/install_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,15 +104,38 @@ func TestApplyResources(t *testing.T) {
 		}
 	})
 
-	t.Run("EmptyRawErrors", func(t *testing.T) {
-		t.Parallel()
+	// Empty documents (e.g. a leading comment block before the first "---")
+	// unmarshal to an empty RawExtension. They must be skipped rather than
+	// rejected, and resources alongside them still applied.
+	skipCases := map[string]struct {
+		reason    string
+		resources []runtime.RawExtension
+		wantErr   error
+		wantName  string
+	}{
+		"SkipsEmptyDocumentAndAppliesRest": {
+			reason:    "An empty document alongside a real resource is skipped, and the real resource is still applied.",
+			resources: []runtime.RawExtension{{}, {Raw: configMapJSON("real")}},
+			wantErr:   nil,
+			wantName:  "real",
+		},
+	}
+	for name, tc := range skipCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-		cl := newFakeClient(t)
-		err := ApplyResources(t.Context(), cl, []runtime.RawExtension{{}})
-		if err == nil {
-			t.Fatal("expected error for empty raw, got nil")
-		}
-	})
+			cl := newFakeClient(t)
+			err := ApplyResources(t.Context(), cl, tc.resources)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("%s\nApplyResources(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+
+			var got corev1.ConfigMap
+			if err := cl.Get(t.Context(), types.NamespacedName{Name: tc.wantName, Namespace: "default"}, &got); err != nil {
+				t.Errorf("%s\nconfigmap %q not found: %v", tc.reason, tc.wantName, err)
+			}
+		})
+	}
 }
 
 func TestLookupLockPackage(t *testing.T) {


### PR DESCRIPTION
### Description of your changes


`crossplane project run --init-resources`/`--extra-resources` rejected any manifest whose first YAML document is empty — most commonly a file-level comment header before the first `---`, a very common convention — with:

```
encountered an invalid or empty raw resource
```

The YAML stream loader (`LoadYAMLStreamFromFile`) splits on `---` and only drops byte-empty chunks, so a comment-only chunk survives, unmarshals to an empty `runtime.RawExtension`, and `ApplyResources` treated that as fatal. `kubectl apply -f` on the identical file works because it skips empty/null documents.

This changes `ApplyResources` to skip empty raw resources (matching kubectl) instead of erroring, which fixes both `--init-resources` and `--extra-resources` since they share the path. The existing `EmptyRawErrors` unit test becomes `SkipsEmptyRaw`, asserting an empty document is skipped and a real resource alongside it is still applied.


Encountered in https://github.com/modelplaneai/modelplane/pull/365 , see `run.sh` there for additional context.

#### Reproduction

```console
$ printf '# header comment\n---\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: demo\n' > prereq.yaml

$ crossplane project run --init-resources prereq.yaml
# before: Error: encountered an invalid or empty raw resource

$ kubectl apply --dry-run=client -f prereq.yaml   # the same file applies fine
```

Fixes #207

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` — passes locally (generate-check, go-lint, and test all green for this commit). Also verified `go build ./...`, `go vet`, `gofmt`, and `golangci-lint run` (0 issues) directly.
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ Bug fix with no user-facing docs change.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ Leaving the backport decision to maintainers.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute