### PR TITLE
schemas: Indent .lock.json for readability

### DIFF
--- a/internal/schemas/manager/manager.go
+++ b/internal/schemas/manager/manager.go
@@ -231,10 +231,13 @@ func (m *Manager) updateLock(l *lock) error {
 		return errors.Wrap(err, "failed to ensure schema directory exists")
 	}
 
-	bs, err := json.Marshal(l)
+	bs, err := json.MarshalIndent(l, "", "  ")
 	if err != nil {
 		return errors.Wrap(err, "failed to serialize schema lock")
 	}
+	// Append a trailing newline so the file ends cleanly and edits to the last
+	// entry produce minimal diffs.
+	bs = append(bs, '\n')
 
 	if err := afero.WriteFile(m.fs, lockFileName, bs, 0o600); err != nil {
 		return errors.Wrap(err, "failed to write schema lock file")

--- a/internal/schemas/manager/manager_test.go
+++ b/internal/schemas/manager/manager_test.go
@@ -171,6 +171,38 @@ func TestManager_Add(t *testing.T) {
 	}
 }
 
+func TestUpdateLockIsIndented(t *testing.T) {
+	// The lock file must be written with one entry per line (indented) so it is
+	// human-readable and avoids spurious merge conflicts. See issue #168.
+	fs := afero.NewMemMapFs()
+	m := New(fs, nil, nil)
+
+	l := newLock()
+	l.Packages["xpkg://pkg.example/bar:v1.0.0"] = "sha256:bbb"
+	l.Packages["xpkg://pkg.example/foo:v0.5.2"] = "sha256:aaa"
+
+	if err := m.updateLock(l); err != nil {
+		t.Fatalf("updateLock: %v", err)
+	}
+
+	got, err := afero.ReadFile(fs, lockFileName)
+	if err != nil {
+		t.Fatalf("read lock: %v", err)
+	}
+
+	// Map keys are marshalled in sorted order, so this golden is deterministic.
+	want := `{
+  "packages": {
+    "xpkg://pkg.example/bar:v1.0.0": "sha256:bbb",
+    "xpkg://pkg.example/foo:v0.5.2": "sha256:aaa"
+  }
+}
+`
+	if diff := cmp.Diff(want, string(got)); diff != "" {
+		t.Errorf("lock file is not indented as expected (-want +got):\n%s", diff)
+	}
+}
+
 type mockGenerator struct {
 	files map[string]string
 }


### PR DESCRIPTION
### Description of your changes

`schemas/.lock.json` was written on a single line, which is hard to read and
causes avoidable merge conflicts whenever more than one dependency changes.

This writes the lock file with `json.MarshalIndent` (two-space indent) plus a
trailing newline, so each dependency is on its own line. Reads are unaffected:
`getLock` decodes with a `json.Decoder`, and indented JSON is still valid. Map
keys marshal in sorted order, so the output is deterministic.

Fixes #168

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `./nix.sh flake check` to ensure this PR is ready for review.~~ Ran `go test ./internal/schemas/manager/... ./internal/dependency/...`, `go vet`, and `gofmt`, and reviewed the change against `.golangci.yml`; relied on CI for the full flake check.
- [x] Added or updated unit tests. (Added `TestUpdateLockIsIndented`.)
- [ ] ~~Linked a PR or a docs tracking issue to document this change.~~ Internal on-disk lock file format; no user-facing docs.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~ Minor readability change; left to maintainer discretion.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
