### PR TITLE
build: Calculate checksums after the nix fixup phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,17 @@ jobs:
       - name: Build Artifacts
         run: nix build .#release --option warn-dirty false --print-build-logs
 
+      - name: Validate Artifacts
+        run: |
+          for f in $(find result/ -type f -not -name '*.sha256'); do
+            want=$(sha256sum "${f}" | head -c 64)
+            got=$(cat "${f}.sha256")
+            if [[ "${want}" != "${got}" ]]; then
+              echo "File ${f} has incorrect checksum; want ${want}, got ${got}"
+              exit 1
+            fi
+          done
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -45,6 +45,9 @@ let
           mv $out/bin/${platform.os}_${platform.arch}/* $out/bin/
           rmdir $out/bin/${platform.os}_${platform.arch}
         fi
+      '';
+
+      postFixup = ''
         cd $out/bin
         sha256sum ${pname}${ext} | head -c 64 > ${pname}${ext}.sha256
       '';


### PR DESCRIPTION
### Description of your changes

crossplane/crossplane#7467 reported that checksums for the amd64 crank binaries in our releases are incorrect. It turns out this applies to both the CLI (now the crossplane binary from this repository) and the core crossplane controller binary (the crossplane binary in c/c).

The issue is that Nix strips binaries in its `fixup` build phase, which runs after our `postInstall` hook. The stripping applies only to binaries for the host architecture, which in our release actions is always amd64.

Calculate checksums in the `postFixup` phase so that we checksum the already stripped binary. Add a checksum verification step before uploading artifacts to catch any similar issues in the future.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
