### PR TITLE
feat: Allow custom type declaration in SimpleSchema

### DIFF
--- a/cmd/crossplane/xrd/generate.go
+++ b/cmd/crossplane/xrd/generate.go
@@ -249,7 +249,7 @@ func newXRDFromSimpleSchema(yamlData []byte, customPlural string) (*v2.Composite
 		plural = flect.Pluralize(kind)
 	}
 
-	specSchema, err := simpleschema.ToOpenAPISpec(simpleInput.Spec, nil)
+	specSchema, err := simpleschema.ToOpenAPISpec(simpleInput.Spec, simpleInput.CustomTypes)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to convert spec to OpenAPI schema")
 	}
@@ -259,7 +259,7 @@ func newXRDFromSimpleSchema(yamlData []byte, customPlural string) (*v2.Composite
 		celPaths := findCELFields(simpleInput.Status, nil)
 		processedStatus := replaceCELWithPlaceholder(simpleInput.Status)
 
-		statusSchema, err = simpleschema.ToOpenAPISpec(processedStatus, nil)
+		statusSchema, err = simpleschema.ToOpenAPISpec(processedStatus, simpleInput.CustomTypes)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to convert status to OpenAPI schema")
 		}
@@ -320,6 +320,7 @@ type inputXR struct {
 	Spec                     map[string]any                         `json:"spec"`
 	Status                   map[string]any                         `json:"status"`
 	AdditionalPrinterColumns []extv1.CustomResourceColumnDefinition `json:"additionalPrinterColumns"`
+	CustomTypes              map[string]any                         `json:"customTypes"`
 }
 
 // newXRDFromExample creates an XRD based on an example XR, ineferring property types

--- a/cmd/crossplane/xrd/generate_test.go
+++ b/cmd/crossplane/xrd/generate_test.go
@@ -733,6 +733,87 @@ spec:
 				},
 			},
 		},
+		"SimpleSchemaWithCustomTypes": {
+			args: args{
+				inputYAML: `
+apiVersion: aws.u5d.io/v1
+kind: XEKS
+metadata:
+  name: test
+spec:
+  request: myType
+status:
+  result: myType
+customTypes:
+  myType:
+    value1: string | required=true
+    value2: integer | default=42
+`,
+				customPlural: "xeks",
+			},
+			want: want{
+				xrd: &v2.CompositeResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "apiextensions.crossplane.io/v2",
+						Kind:       "CompositeResourceDefinition",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "xeks.aws.u5d.io",
+					},
+					Spec: v2.CompositeResourceDefinitionSpec{
+						Group: "aws.u5d.io",
+						Scope: v2.CompositeResourceScopeNamespaced,
+						Names: extv1.CustomResourceDefinitionNames{
+							Categories: []string{"crossplane"},
+							Kind:       "XEKS",
+							Plural:     "xeks",
+						},
+						Versions: []v2.CompositeResourceDefinitionVersion{
+							{
+								Name:          "v1",
+								Referenceable: true,
+								Served:        true,
+								Schema: &v2.CompositeResourceValidation{
+									OpenAPIV3Schema: jsonSchemaPropsToRawExtension(&extv1.JSONSchemaProps{
+										Description: "XEKS is the Schema for the XEKS API.",
+										Type:        "object",
+										Properties: map[string]extv1.JSONSchemaProps{
+											"spec": {
+												Type: "object",
+												Properties: map[string]extv1.JSONSchemaProps{
+													"request": {
+														Type:     "object",
+														Required: []string{"value1"},
+														Properties: map[string]extv1.JSONSchemaProps{
+															"value1": {Type: "string"},
+															"value2": {Type: "integer", Default: &extv1.JSON{Raw: []byte("42")}},
+														},
+													},
+												},
+											},
+											"status": {
+												Type: "object",
+												Properties: map[string]extv1.JSONSchemaProps{
+													"result": {
+														Type:     "object",
+														Required: []string{"value1"},
+														Properties: map[string]extv1.JSONSchemaProps{
+															"value1": {Type: "string"},
+															"value2": {Type: "integer", Default: &extv1.JSON{Raw: []byte("42")}},
+														},
+													},
+												},
+											},
+										},
+										Required: []string{"spec"},
+									}),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
### Description of your changes

Allows the definition of custom types within a SimpleSchema declaration.
Looks like:
```yaml
apiVersion: aws.u5d.io/v1
kind: XEKS
metadata:
  name: test
spec:
  request: myType
status:
  result: myType
customTypes:
  myType:
    value1: string | required=true
    value2: integer | default=42
```

Fixes #199 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
