### PR TITLE
fix(common/load/streamToUnstructured): skip empty documents

### DIFF
--- a/cmd/crossplane/common/load/loader.go
+++ b/cmd/crossplane/common/load/loader.go
@@ -208,6 +208,12 @@ func streamToUnstructured(stream [][]byte) ([]*unstructured.Unstructured, error)
 		if err := yaml.Unmarshal(y, u); err != nil {
 			return nil, errors.Wrap(err, "cannot parse YAML manifest")
 		}
+
+		// skip empty documents (empty files, or documents containing only comment)
+		if len(u.Object) == 0 {
+			continue
+		}
+
 		// extract pipeline input resources
 		if u.GetObjectKind().GroupVersionKind() == v1.CompositionGroupVersionKind {
 			// Convert the unstructured resource to a Composition

--- a/cmd/crossplane/common/load/loader_test.go
+++ b/cmd/crossplane/common/load/loader_test.go
@@ -495,6 +495,15 @@ spec:
 				resources: []*unstructured.Unstructured{},
 			},
 		},
+		"SkipDocumentsWithCommentOnly": {
+			reason: "Skip documents with only comments",
+			args: args{
+				stream: [][]byte{[]byte("# comment only\n")},
+			},
+			want: want{
+				resources: []*unstructured.Unstructured{},
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/cmd/crossplane/common/load/loader_test.go
+++ b/cmd/crossplane/common/load/loader_test.go
@@ -486,6 +486,15 @@ spec:
 				err: nil,
 			},
 		},
+		"SkipEmptyDocuments": {
+			reason: "Return empty unstructured array for empty documents",
+			args: args{
+				stream: [][]byte{{}},
+			},
+			want: want{
+				resources: []*unstructured.Unstructured{},
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Reimplementing https://github.com/crossplane/crossplane/pull/7089.

The `streamToUnstructured()` function loads a stream of yaml into unstructured objects, and is used by different Loaders during beta validate.
If a yaml document in the stream only contains a comment, or the file is empty, this function will currently not fail, but add an empty object to the unstructured array, resulting in this warning during validation in `resource validate`: [!] could not find CRD/XRD for: /, Kind=

A simple example of where this might be an issue: 

We generate the rendered resources that should be validated with a tool that wraps around crossplane render functionality.
Since we want the user to know that these files were generated, we add the following comment at the top:

```yaml
# Generated by: x
# Do not edit this file manually
---
apiVersion: example.io/v1alpha1
kind: SomeResource
metadata:
  name: example
spec: {}
---
other resources...
```

But these comment results in the empty document issue when passing this file to the validate command.

Since this is valid yaml i believe the best thing is to fix what i believe is a logical issue in this function, instead of changing the generated file to accommodate.

I added a test and fix that ensures streamToUnstructured() skips empty objects like this.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~~- [] Linked a PR or a [docs tracking issue] to [document this change].~~
~~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
