### PR TITLE
generator: make generated Go getters tolerate a nil receiver

### DIFF
--- a/internal/schemas/generator/accessors.go
+++ b/internal/schemas/generator/accessors.go
@@ -130,6 +130,22 @@ func receiverTypeName(e ast.Expr) string {
 	return ""
 }
 
+// isNilable reports whether a zero value of the given type is spelled `nil`,
+// letting the generated getter return nil directly instead of declaring a zero
+// variable. Generated models use pointers throughout, so this is the common
+// case; the zero-variable form covers everything else.
+func isNilable(e ast.Expr) bool {
+	switch t := e.(type) {
+	case *ast.StarExpr, *ast.MapType, *ast.InterfaceType, *ast.ChanType, *ast.FuncType:
+		return true
+	case *ast.ArrayType:
+		// Slices are nilable; fixed-size arrays are not.
+		return t.Len == nil
+	default:
+		return false
+	}
+}
+
 // writeStructAccessors appends a getter and setter for each named field of the
 // given struct to b. Any accessor whose name already exists in skip is omitted
 // to avoid colliding with methods oapi-codegen already generated.
@@ -158,10 +174,20 @@ func writeStructAccessors(b *strings.Builder, fset *token.FileSet, typeName stri
 
 			fieldName := name.Name
 
-			// Getter.
+			// Getter. It tolerates a nil receiver so that chained getters are
+			// safe on partially-populated resources.
 			if !skip["Get"+fieldName] {
 				b.WriteString("\n// Get" + fieldName + " returns the " + fieldName + " field.\n")
+				b.WriteString("// It returns the zero value if the receiver is nil.\n")
 				b.WriteString("func (" + accessorReceiver + " *" + typeName + ") Get" + fieldName + "() " + fieldType + " {\n")
+				b.WriteString("\tif " + accessorReceiver + " == nil {\n")
+				if isNilable(field.Type) {
+					b.WriteString("\t\treturn nil\n")
+				} else {
+					b.WriteString("\t\tvar zero " + fieldType + "\n")
+					b.WriteString("\t\treturn zero\n")
+				}
+				b.WriteString("\t}\n")
 				b.WriteString("\treturn " + accessorReceiver + "." + fieldName + "\n")
 				b.WriteString("}\n")
 			}

--- a/internal/schemas/generator/accessors_test.go
+++ b/internal/schemas/generator/accessors_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -251,6 +252,12 @@ func useAccessors(a specAccessor) *v1alpha1.XAccountScaffoldSpec {
 }
 
 var _ = useAccessors
+
+// ChainOnEmpty walks nested getters on a resource whose intermediate structs are
+// all nil. It must return the zero value rather than panicking.
+func ChainOnEmpty() *string {
+	return (&v1alpha1.XAccountScaffold{}).GetSpec().GetParameters().GetName()
+}
 `
 	consumerDir := filepath.Join(dir, "models", "consumer")
 	if err := os.MkdirAll(consumerDir, 0o755); err != nil {
@@ -279,6 +286,28 @@ var _ = useAccessors
 	cmd.Dir = modelsDir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("generated models failed to compile: %v\n%s", err, out)
+	}
+
+	// Compiling proves the chain typechecks; running it proves the nil guards
+	// actually hold. Without them ChainOnEmpty panics on the first hop.
+	consumerTest := `package consumer
+
+import "testing"
+
+func TestChainOnEmptyDoesNotPanic(t *testing.T) {
+	if got := ChainOnEmpty(); got != nil {
+		t.Errorf("expected nil from a chain over an empty resource, got %v", *got)
+	}
+}
+`
+	if err := os.WriteFile(filepath.Join(consumerDir, "consumer_test.go"), []byte(consumerTest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd = exec.CommandContext(t.Context(), "go", "test", "./consumer/...")
+	cmd.Dir = modelsDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("chained getters panicked on an empty resource: %v\n%s", err, out)
 	}
 }
 
@@ -324,6 +353,87 @@ type FooAlias = Foo
 
 	if diff := cmp.Diff(want, collectMethods(t, got)); diff != "" {
 		t.Errorf("generated accessors (-want +got):\n%s", diff)
+	}
+}
+
+// guardsNilReceiver reports whether the body of method recv.name opens with an
+// `if <receiver> == nil` guard.
+func guardsNilReceiver(t *testing.T, src, recv, name string) bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("failed to parse source: %v\n%s", err, src)
+	}
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv == nil || len(fn.Recv.List) != 1 {
+			continue
+		}
+		if receiverTypeName(fn.Recv.List[0].Type) != recv || fn.Name.Name != name {
+			continue
+		}
+		if fn.Body == nil || len(fn.Body.List) == 0 {
+			return false
+		}
+		ifs, ok := fn.Body.List[0].(*ast.IfStmt)
+		if !ok {
+			return false
+		}
+		bin, ok := ifs.Cond.(*ast.BinaryExpr)
+		if !ok || bin.Op != token.EQL {
+			return false
+		}
+		x, okX := bin.X.(*ast.Ident)
+		y, okY := bin.Y.(*ast.Ident)
+		return okX && okY && x.Name == accessorReceiver && y.Name == "nil"
+	}
+	t.Fatalf("method %s.%s not found", recv, name)
+	return false
+}
+
+// TestAddAccessorsGuardsNilReceiver verifies that getters tolerate a nil
+// receiver, which is what makes chained getters safe on partially-populated
+// resources. Setters are deliberately left unguarded: a set on a nil receiver
+// has nowhere to store the value, so panicking is the honest behaviour.
+func TestAddAccessorsGuardsNilReceiver(t *testing.T) {
+	input := `package v1alpha1
+
+type Foo struct {
+	Bar   *Bar    ` + "`json:\"bar,omitempty\"`" + `
+	Name  *string ` + "`json:\"name,omitempty\"`" + `
+	Count int64   ` + "`json:\"count\"`" + `
+	Fixed [2]byte ` + "`json:\"fixed\"`" + `
+}
+
+type Bar struct {
+	Count *int64 ` + "`json:\"count,omitempty\"`" + `
+}
+`
+
+	got, err := addAccessors(input)
+	if err != nil {
+		t.Fatalf("addAccessors returned error: %v", err)
+	}
+
+	for _, name := range []string{"GetBar", "GetName", "GetCount", "GetFixed"} {
+		if !guardsNilReceiver(t, got, "Foo", name) {
+			t.Errorf("Foo.%s must guard against a nil receiver", name)
+		}
+	}
+	if guardsNilReceiver(t, got, "Foo", "SetBar") {
+		t.Error("Foo.SetBar must not silently swallow a nil receiver")
+	}
+
+	// Nilable types return nil directly; non-nilable types need a zero value.
+	if !strings.Contains(got, "func (o *Foo) GetBar() *Bar {\n\tif o == nil {\n\t\treturn nil\n\t}") {
+		t.Errorf("GetBar should return nil for a nilable field, got:\n%s", got)
+	}
+	if !strings.Contains(got, "var zero int64") {
+		t.Errorf("GetCount should declare a zero value for a non-nilable field, got:\n%s", got)
+	}
+	if !strings.Contains(got, "var zero [2]byte") {
+		t.Errorf("GetFixed should treat a fixed-size array as non-nilable, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
### Description of your changes

Follow-up to #160.

## Problem

The generated accessors return their field directly:

```go
func (o *XComponentDefinitionEnvStatus) GetProviderConfigRefs() *...ProviderConfigRefs {
	return o.ProviderConfigRefs
}
```

So walking nested getters panics as soon as an intermediate struct is nil:

```go
cd.GetStatus().GetProviderConfigRefs().GetAws().GetName() // panic
```

`goRemoveRequired` makes every field of a generated model optional, so intermediate
nils are the normal case for a partially-populated resource, not an edge case — a
status subresource that the controller hasn't filled in yet hits this immediately.
Callers end up writing explicit nil checks at every hop, which is most of what the
accessors were meant to remove.

## What this does

Guards each getter with a nil-receiver check, the way protobuf-generated getters do,
so a chain over absent fields yields the zero value instead of panicking:

```go
func (o *XComponentDefinitionEnvStatus) GetProviderConfigRefs() *...ProviderConfigRefs {
	if o == nil {
		return nil
	}
	return o.ProviderConfigRefs
}
```

Nilable field types return `nil` directly. Anything else — a value field, a fixed-size
array — returns a declared zero value, so the guard is correct for field shapes the
generator doesn't currently emit but could.

Setters are deliberately left unguarded: a set on a nil receiver has nowhere to store
the value, so panicking is the honest behaviour rather than silently dropping a write.

## What this does not do

Scalar getters keep returning pointers (`GetName() *string`, not `string`). Protobuf
returns values for scalars, but for Kubernetes APIs the nil-vs-empty distinction is
load-bearing — `omitempty`, patch semantics, and "unset" versus "explicitly empty" are
all observable. Collapsing that would lose information, and the pointer return keeps
`GetX`/`SetX` symmetric. Callers still need one nil check at the end of a chain, not one
per hop.

## Compatibility

Getter signatures are unchanged, and this only widens the set of receivers a getter
accepts, so no code that works today breaks. #160 is also not in a release yet, so
there are no released consumers either way.

## Testing

- `TestAddAccessorsGuardsNilReceiver` — asserts every getter opens with the nil guard,
  that setters do *not*, and that nilable fields return `nil` while a value field and a
  fixed-size array get a declared zero.
- The existing compile gate now also **runs** what it builds: the consumer chains
  getters over an empty resource, and the materialized module is `go test`ed. Compiling
  alone would not have caught this, since the old code typechecks fine and only fails at
  runtime.
- Verified the new tests fail without the generator change — the runtime test panics with
  a nil pointer dereference, which is the bug being fixed.
- Also regenerated a real 24-XRD project (~58k LOC of models) with the patched binary and
  confirmed `cd.GetStatus().GetProviderConfigRefs().GetAws().GetName()` returns nil on an
  empty resource instead of panicking.

`go test ./...`, `go vet ./...`, `go build ./...` and `gofmt -l .` are all clean.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

On the struck items: `nix` isn't available in the environment this was developed in, so
`flake check` hasn't been run — `go test`/`go vet`/`gofmt` were run instead, and I'd
appreciate CI or a reviewer confirming the flake. This changes the body of generated
methods rather than any user-facing command or help text, so there's nothing for
`crossplane/docs` to pick up. And it fixes an unreleased feature from #160, so it isn't a
backport candidate.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
