### PR TITLE
render: Ignore the observed copy of the XR in --observed-resources

### DIFF
--- a/cmd/crossplane/render/convert.go
+++ b/cmd/crossplane/render/convert.go
@@ -57,7 +57,7 @@ func BuildCompositeRequest(in CompositionInputs) (*renderv1alpha1.RenderRequest,
 		})
 	}
 
-	observedStructs, err := composedToStructs(in.ObservedResources)
+	observedStructs, err := composedToStructs(filterObservedXR(in.ObservedResources, in.CompositeResource))
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot convert observed resources to protobuf")
 	}
@@ -276,6 +276,27 @@ func asStructFromTyped(o runtime.Object) (*structpb.Struct, error) {
 	}
 	u := &kunstructured.Unstructured{Object: data}
 	return resource.AsStruct(u)
+}
+
+// filterObservedXR drops any observed resource that is really the composite
+// resource itself. A render run emits the XR as its first output document, so
+// an --observed-resources file produced by a previous run usually contains a
+// UID-less copy of the XR. Keyed by GVK+namespace+name, that copy would
+// overwrite the real XR in the engine's store and blank its UID, causing the
+// ownership check to drop every composed resource. The XR is already supplied
+// as the positional argument, so the copy is redundant. See issue #47.
+func filterObservedXR(observed []composed.Unstructured, xr *ucomposite.Unstructured) []composed.Unstructured {
+	out := make([]composed.Unstructured, 0, len(observed))
+	for i := range observed {
+		o := observed[i]
+		if o.GroupVersionKind() == xr.GroupVersionKind() &&
+			o.GetNamespace() == xr.GetNamespace() &&
+			o.GetName() == xr.GetName() {
+			continue
+		}
+		out = append(out, o)
+	}
+	return out
 }
 
 func composedToStructs(resources []composed.Unstructured) ([]*structpb.Struct, error) {

--- a/cmd/crossplane/render/convert_test.go
+++ b/cmd/crossplane/render/convert_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package render
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource/unstructured/composed"
+	ucomposite "github.com/crossplane/crossplane-runtime/v2/pkg/resource/unstructured/composite"
+)
+
+func TestFilterObservedXR(t *testing.T) {
+	type args struct {
+		xr       *ucomposite.Unstructured
+		observed []composed.Unstructured
+	}
+
+	// composite builds a composite resource (XR) with the given identity.
+	composite := func(apiVersion, kind, namespace, name string) *ucomposite.Unstructured {
+		xr := ucomposite.New()
+		xr.SetAPIVersion(apiVersion)
+		xr.SetKind(kind)
+		xr.SetNamespace(namespace)
+		xr.SetName(name)
+		return xr
+	}
+
+	// observed builds an observed composed resource with the given identity.
+	observed := func(apiVersion, kind, namespace, name string) composed.Unstructured {
+		o := composed.New()
+		o.SetAPIVersion(apiVersion)
+		o.SetKind(kind)
+		o.SetNamespace(namespace)
+		o.SetName(name)
+		return *o
+	}
+
+	// keys projects resources to comparable "apiVersion/kind/namespace/name"
+	// strings so we compare identity rather than the underlying maps.
+	keys := func(rs []composed.Unstructured) []string {
+		out := make([]string, len(rs))
+		for i := range rs {
+			out[i] = fmt.Sprintf("%s/%s/%s/%s", rs[i].GetAPIVersion(), rs[i].GetKind(), rs[i].GetNamespace(), rs[i].GetName())
+		}
+		return out
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   []string
+	}{
+		"DropsObservedCopyOfXR": {
+			// The observed file contains a copy of the XR (as `crossplane
+			// render` emits it) alongside a real composed resource. Only the
+			// composed resource should survive.
+			reason: "An observed resource matching the XR's GVK, namespace and name should be dropped.",
+			args: args{
+				xr: composite("example.org/v1", "XR", "default", "my-xr"),
+				observed: []composed.Unstructured{
+					observed("example.org/v1", "XR", "default", "my-xr"),
+					observed("example.org/v1", "Composed", "default", "cd-a"),
+				},
+			},
+			want: []string{"example.org/v1/Composed/default/cd-a"},
+		},
+		"KeepsAllWhenNoXRCopy": {
+			reason: "Observed resources should be returned untouched when none of them is the XR.",
+			args: args{
+				xr: composite("example.org/v1", "XR", "default", "my-xr"),
+				observed: []composed.Unstructured{
+					observed("example.org/v1", "Composed", "default", "cd-a"),
+					observed("example.org/v1", "Composed", "default", "cd-b"),
+				},
+			},
+			want: []string{
+				"example.org/v1/Composed/default/cd-a",
+				"example.org/v1/Composed/default/cd-b",
+			},
+		},
+		"DropsClusterScopedXRCopy": {
+			// Cluster-scoped XR: namespace is empty on both the XR and its copy.
+			reason: "An observed copy of a cluster scoped XR should be dropped, matching on an empty namespace.",
+			args: args{
+				xr: composite("example.org/v1", "XR", "", "my-xr"),
+				observed: []composed.Unstructured{
+					observed("example.org/v1", "XR", "", "my-xr"),
+					observed("example.org/v1", "Composed", "", "cd-a"),
+				},
+			},
+			want: []string{"example.org/v1/Composed//cd-a"},
+		},
+		"KeepsSameNameDifferentKind": {
+			// A resource sharing the XR's name and namespace but a different
+			// kind is not the XR and must be kept.
+			reason: "An observed resource sharing the XR's namespace and name but not its kind should be kept.",
+			args: args{
+				xr: composite("example.org/v1", "XR", "default", "my-xr"),
+				observed: []composed.Unstructured{
+					observed("example.org/v1", "Other", "default", "my-xr"),
+				},
+			},
+			want: []string{"example.org/v1/Other/default/my-xr"},
+		},
+		"EmptyObserved": {
+			reason: "No observed resources should produce no observed resources.",
+			args: args{
+				xr:       composite("example.org/v1", "XR", "default", "my-xr"),
+				observed: nil,
+			},
+			want: []string{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := filterObservedXR(tc.args.observed, tc.args.xr)
+			if diff := cmp.Diff(tc.want, keys(got)); diff != "" {
+				t.Errorf("\n%s\nfilterObservedXR(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

`crossplane render` emits the composite resource as its first output document.
When that output is fed back in via `--observed-resources` — the iterative
workflow the issue describes — the file contains a UID-less copy of the XR.
Observed resources are keyed by GVK, namespace and name, so that copy
overwrites the real XR in the engine's store and blanks its UID. The ownership
check then matches nothing, and every composed resource is silently dropped
from the output.

The XR is already supplied as the positional argument, so this drops the
redundant observed copy when building the render request.

This is the conservative fix discussed on the issue. @adamwg suggested that
rather than ignoring the observed XR we could merge it into the explicitly
supplied one, so an iterative run could feed back status fields set by a
previous render. That seems useful, but it is a behaviour change layered on top
of a currently-silent data loss bug, so I would suggest landing this first and
treating the merge semantics as a follow-up — happy to pick that up.

Covered by `TestFilterObservedXR`: the observed copy is dropped for both
namespaced and cluster-scoped XRs, a resource sharing the XR's name and
namespace but not its kind is kept, and the no-copy and empty-input cases are
left untouched.

Fixes #47

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `./nix.sh flake check` to ensure this PR is ready for review.~~ Ran `go build ./...`, `go vet ./cmd/crossplane/render/...`, `gofmt`, and `go test ./cmd/crossplane/render/...` locally, all clean; relied on CI for the full flake check.
- [x] Added or updated unit tests. (Added `TestFilterObservedXR`.)
- [ ] ~~Linked a PR or a docs tracking issue to document this change.~~ Restores the documented behaviour of `--observed-resources`; no docs change needed.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR.~~ Left to maintainer discretion, though this may be worth backporting since it is silent data loss.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
