### PR TITLE
fix(schemas): fix Go model generation for validation-only combinators and shared k8s package collisions

### DIFF
--- a/internal/schemas/generator/go.go
+++ b/internal/schemas/generator/go.go
@@ -290,6 +290,7 @@ func (g goGenerator) GenerateFromCRD(_ context.Context, fromFS afero.Fs, _ runne
 	// Generate models for the non-k8s schemas.
 	for _, oapi := range openAPIs {
 		code, err := generateGo(oapi.spec, oapi.version,
+			goRemoveValidationOnlyCombinators,
 			goRenameTypes,
 			goRenameEnums,
 			goReplaceNumberWithInt,
@@ -369,6 +370,7 @@ func (g goGenerator) generateSharedK8sPackage(schemaFS afero.Fs, pkg string, sch
 	}
 
 	code, err := generateGo(pkgSpec, goPkg.version,
+		goRemoveValidationOnlyCombinators,
 		goRenameTypes,
 		goRenameEnums,
 		goReplaceNumberWithInt,
@@ -739,6 +741,16 @@ func goSchemaPath(group, kind, version string) string {
 	switch group {
 	case "apps", k8sPkgNameAutoscaling, "batch", "policy":
 		return filepath.Join("io", "k8s", group, version, strings.ToLower(kind)+".go")
+	case "resource.k8s.io":
+		// The resource.k8s.io group (dynamic resource allocation) would
+		// collide with the shared apimachinery Quantity package at
+		// io/k8s/resource/v1, so it lives under io/k8s/api/resource instead,
+		// mirroring the upstream k8s.io/api/resource layout.
+		return filepath.Join("io", "k8s", "api", "resource", version, strings.ToLower(kind)+".go")
+	case "resource.apimachinery.k8s.io":
+		// Pseudo-group for the shared apimachinery Quantity package; it keeps
+		// its historical path at io/k8s/resource/v1.
+		return filepath.Join("io", "k8s", "resource", version, strings.ToLower(kind)+".go")
 	}
 
 	path := strings.Split(group, ".")
@@ -866,6 +878,85 @@ func goRetypeSchema(schema *spec.Schema, oldType, newType string) {
 	if schema.Type.Contains(oldType) {
 		schema.AddExtension("x-go-type", newType)
 	}
+}
+
+// goRemoveValidationOnlyCombinators removes anyOf/oneOf combinators that carry
+// no structural type information. Kubernetes structural schemas allow these
+// junctors only for validation (e.g. "exactly one of endpointSelector and
+// nodeSelector must be set"), where each variant contains only `required`
+// constraints and empty property schemas. oapi-codegen generates a union
+// member type named <TypeName><index> for each variant, so a schema with both
+// anyOf and oneOf produces colliding type names (two <TypeName>0). The
+// variants don't affect the generated Go structs, so we drop them.
+// Combinators with typed variants (e.g. x-kubernetes-int-or-string's
+// anyOf: [{type: integer}, {type: string}]) are kept.
+func goRemoveValidationOnlyCombinators(s *spec3.OpenAPI) {
+	for _, schema := range s.Components.Schemas {
+		goRemoveSchemaValidationOnlyCombinators(schema)
+	}
+}
+
+func goRemoveSchemaValidationOnlyCombinators(schema *spec.Schema) {
+	if schema == nil {
+		return
+	}
+
+	if goCombinatorIsValidationOnly(schema.AnyOf) {
+		schema.AnyOf = nil
+	}
+	if goCombinatorIsValidationOnly(schema.OneOf) {
+		schema.OneOf = nil
+	}
+
+	for i := range schema.AllOf {
+		goRemoveSchemaValidationOnlyCombinators(&schema.AllOf[i])
+	}
+	for i := range schema.AnyOf {
+		goRemoveSchemaValidationOnlyCombinators(&schema.AnyOf[i])
+	}
+	for i := range schema.OneOf {
+		goRemoveSchemaValidationOnlyCombinators(&schema.OneOf[i])
+	}
+	for name, prop := range schema.Properties {
+		goRemoveSchemaValidationOnlyCombinators(&prop)
+		schema.Properties[name] = prop
+	}
+	if schema.Items != nil && schema.Items.Schema != nil {
+		goRemoveSchemaValidationOnlyCombinators(schema.Items.Schema)
+	}
+	if schema.AdditionalProperties != nil && schema.AdditionalProperties.Schema != nil {
+		goRemoveSchemaValidationOnlyCombinators(schema.AdditionalProperties.Schema)
+	}
+}
+
+// goCombinatorIsValidationOnly returns true if all the given anyOf/oneOf
+// variants constrain validation without describing any structure.
+func goCombinatorIsValidationOnly(variants []spec.Schema) bool {
+	if len(variants) == 0 {
+		return false
+	}
+	for i := range variants {
+		if !goSchemaIsValidationOnly(&variants[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func goSchemaIsValidationOnly(s *spec.Schema) bool {
+	if len(s.Type) > 0 || s.Ref.String() != "" || s.Format != "" ||
+		s.Items != nil || s.AdditionalProperties != nil ||
+		len(s.Enum) > 0 || s.Default != nil ||
+		len(s.AllOf) > 0 || len(s.AnyOf) > 0 || len(s.OneOf) > 0 || s.Not != nil {
+		return false
+	}
+	for name := range s.Properties {
+		prop := s.Properties[name]
+		if !goSchemaIsValidationOnly(&prop) {
+			return false
+		}
+	}
+	return true
 }
 
 // goRemoveRequired removes the required fields from schemas. We want all fields
@@ -1052,17 +1143,23 @@ func tryReplaceK8sTypeWithMetaPath(schema *spec.Schema, ref string, useCorePath 
 	}
 }
 
+// isSharedK8sSchema returns true if the named schema belongs to one of the
+// k8s packages we generate as shared models for all other models to reference.
+func isSharedK8sSchema(name string) bool {
+	return strings.HasPrefix(name, k8sPkgMetaV1) ||
+		strings.HasPrefix(name, k8sPkgRuntime) ||
+		strings.HasPrefix(name, k8sPkgCoreV1) ||
+		strings.HasPrefix(name, k8sPkgIntStr) ||
+		strings.HasPrefix(name, k8sPkgResource) ||
+		strings.HasPrefix(name, k8sPkgAutoscalingV1)
+}
+
 // goRemoveK8s removes all k8s schemas from the given OpenAPI spec, so
 // that we can generate models for them separately and share them across all our
 // other generated models.
 func goRemoveK8s(s *spec3.OpenAPI) {
 	for name := range s.Components.Schemas {
-		if strings.HasPrefix(name, k8sPkgMetaV1) ||
-			strings.HasPrefix(name, k8sPkgRuntime) ||
-			strings.HasPrefix(name, k8sPkgCoreV1) ||
-			strings.HasPrefix(name, k8sPkgIntStr) ||
-			strings.HasPrefix(name, k8sPkgResource) ||
-			strings.HasPrefix(name, k8sPkgAutoscalingV1) {
+		if isSharedK8sSchema(name) {
 			delete(s.Components.Schemas, name)
 		}
 	}
@@ -1451,6 +1548,7 @@ func generateK8sPackageCode(pkg string, schemas map[string]*spec.Schema, schemaF
 	goPkg := getK8sPackageInfo(pkg)
 
 	code, err := generateGo(pkgSpec, goPkg.version,
+		goRemoveValidationOnlyCombinators,
 		goRenameTypes,
 		goRenameEnums,
 		goReplaceNumberWithInt,
@@ -1506,7 +1604,10 @@ func getK8sPackageInfo(pkg string) goPackage {
 	case k8sPkgIntStr:
 		return goPackage{group: "util.k8s.io", kind: "intstr", version: "v1"}
 	case k8sPkgResource:
-		return goPackage{group: "resource.k8s.io", kind: "resource", version: "v1"}
+		// Pseudo-group to distinguish the shared apimachinery Quantity
+		// package from the real resource.k8s.io API group (dynamic resource
+		// allocation); see goSchemaPath.
+		return goPackage{group: "resource.apimachinery.k8s.io", kind: "resource", version: "v1"}
 	case k8sPkgAutoscalingV1:
 		return goPackage{
 			group:    k8sPkgNameAutoscaling,
@@ -1525,6 +1626,21 @@ func generateModelsWithGVK(openAPISpecs []*spec3.OpenAPI, schemaFS afero.Fs, g g
 		gvkGroups := groupSchemasByGVK(openAPISpec)
 
 		for gvkKey, schemas := range gvkGroups {
+			// Skip groups whose schemas are all shared k8s package schemas
+			// (e.g. autoscaling/v1's Scale). They're generated by
+			// generateK8sSharedSchemas, and goRemoveK8s would leave this group
+			// empty, overwriting the shared package file with an empty one.
+			shared := true
+			for name := range schemas {
+				if !isSharedK8sSchema(name) {
+					shared = false
+					break
+				}
+			}
+			if shared {
+				continue
+			}
+
 			if err := generateGVKGroupCode(gvkKey, schemas, openAPISpec, schemaFS, g); err != nil {
 				return err
 			}
@@ -1616,6 +1732,7 @@ func generateGVKGroupCode(gvkKey string, schemas map[string]*spec.Schema, openAP
 	maps.Copy(groupSpec.Components.Schemas, openAPISpec.Components.Schemas)
 
 	code, err := generateGo(groupSpec, version,
+		goRemoveValidationOnlyCombinators,
 		goRenameTypes,
 		goRenameEnums,
 		goReplaceNumberWithInt,

--- a/internal/schemas/generator/go_test.go
+++ b/internal/schemas/generator/go_test.go
@@ -18,9 +18,11 @@ package generator
 
 import (
 	"embed"
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -30,6 +32,35 @@ import (
 
 //go:embed testdata/*.yaml
 var testdataFS embed.FS
+
+// assertValidTypeDecls fails the test if the given parsed Go file declares the
+// same type twice or declares a self-referential alias (`type X = X`), both of
+// which don't compile but slip through syntax-only parsing.
+func assertValidTypeDecls(t *testing.T, f *ast.File, path string) {
+	t.Helper()
+
+	seen := make(map[string]bool)
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.TYPE {
+			continue
+		}
+		for _, s := range gd.Specs {
+			ts, ok := s.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			if seen[ts.Name.Name] {
+				t.Errorf("duplicate type %s declared in %s", ts.Name.Name, path)
+			}
+			seen[ts.Name.Name] = true
+
+			if ident, ok := ts.Type.(*ast.Ident); ok && ident.Name == ts.Name.Name {
+				t.Errorf("self-referential type %s in %s", ts.Name.Name, path)
+			}
+		}
+	}
+}
 
 func TestGenerateFromCRDGo(t *testing.T) {
 	inputFS := afero.NewBasePathFs(afero.FromIOFS{FS: testdataFS}, "testdata")
@@ -44,6 +75,8 @@ func TestGenerateFromCRDGo(t *testing.T) {
 		"models/co/acme/platform/v1alpha1/accountscaffold.go",
 		"models/co/acme/platform/v1alpha1/xaccountscaffold.go",
 		"models/io/upbound/azure/web/v1beta1/linuxfunctionapp.go",
+		"models/io/cilium/v2/ciliumclusterwidenetworkpolicy.go",
+		"models/com/example/v1/widget.go",
 	}
 
 	files := token.NewFileSet()
@@ -71,6 +104,7 @@ func TestGenerateFromCRDGo(t *testing.T) {
 			if diff := cmp.Diff(expectedPackage, f.Name.Name); diff != "" {
 				t.Errorf("package name (-want +got):\n%s", diff)
 			}
+			assertValidTypeDecls(t, f, path)
 
 		case ".mod":
 			mod, err := modfile.Parse(path, contents, nil)
@@ -81,6 +115,138 @@ func TestGenerateFromCRDGo(t *testing.T) {
 				t.Errorf("module path (-want +got):\n%s", diff)
 			}
 		}
+	}
+}
+
+// TestGenerateFromCRDGoScaleSubresource ensures CRDs with a scale subresource
+// generate a model for the resource itself and don't pull the autoscaling/v1
+// Scale schemas into the generated models. crd.ToOpenAPI drops the scale
+// subresource before building the OpenAPI spec, so no shared autoscaling
+// package must appear in the CRD flow.
+func TestGenerateFromCRDGoScaleSubresource(t *testing.T) {
+	inputFS := afero.NewBasePathFs(afero.FromIOFS{FS: testdataFS}, "testdata")
+	schemaFS, err := goGenerator{}.GenerateFromCRD(t.Context(), inputFS, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contents, err := afero.ReadFile(schemaFS, "models/com/example/v1/widget.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), "type Widget struct") {
+		t.Error("generated code doesn't define Widget")
+	}
+
+	exists, err := afero.Exists(schemaFS, "models/io/k8s/autoscaling/v1/autoscaling.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("scale subresource leaked the autoscaling/v1 Scale schemas into the generated models")
+	}
+}
+
+// TestGenerateFromCRDGoValidationOnlyCombinators ensures we can generate
+// models for CRDs that use anyOf/oneOf purely for validation (e.g. Cilium's
+// "exactly one of endpointSelector and nodeSelector must be set"). Kubernetes
+// structural schemas allow only `required` constraints and empty property
+// schemas inside these junctors, but oapi-codegen would generate a union
+// member type per variant, and a schema with both anyOf and oneOf produces
+// colliding type names (two <TypeName>0). We strip such combinators; typed
+// ones like x-kubernetes-int-or-string's anyOf must be kept.
+func TestGenerateFromCRDGoValidationOnlyCombinators(t *testing.T) {
+	inputFS := afero.NewBasePathFs(afero.FromIOFS{FS: testdataFS}, "testdata")
+	schemaFS, err := goGenerator{}.GenerateFromCRD(t.Context(), inputFS, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contents, err := afero.ReadFile(schemaFS, "models/io/cilium/v2/ciliumclusterwidenetworkpolicy.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := string(contents)
+
+	// The fields referenced by the validation-only combinators must still be
+	// generated from the schema's regular properties.
+	for _, field := range []string{"EndpointSelector", "NodeSelector", "Ingress", "Egress"} {
+		if !strings.Contains(code, field) {
+			t.Errorf("generated code missing field %s", field)
+		}
+	}
+
+	// No union types must be generated for the validation-only combinators on
+	// the spec schema.
+	if strings.Contains(code, "type IoCiliumV2CiliumClusterwideNetworkPolicySpec0") {
+		t.Error("generated code contains a union type for a validation-only combinator")
+	}
+
+	// Typed anyOf variants (x-kubernetes-int-or-string) must still generate
+	// union member types.
+	if !strings.Contains(code, "IoCiliumV2CiliumClusterwideNetworkPolicySpecEgressIcmpsFieldsType0") {
+		t.Error("generated code is missing the int-or-string union member type")
+	}
+}
+
+// TestGenerateFromOpenAPIGoSharedK8sPackages ensures models generated for
+// real k8s API groups don't overwrite the shared k8s packages:
+//
+//   - The resource.k8s.io group (dynamic resource allocation, GA in k8s 1.34)
+//     reverses to the same io/k8s/resource/v1 path as the shared apimachinery
+//     Quantity package. It used to clobber it, leaving a package that imported
+//     itself and creating a core/v1 -> resource/v1 -> core/v1 import cycle.
+//     It now lives at io/k8s/api/resource instead.
+//   - GVK groups whose schemas are all shared k8s package schemas (e.g.
+//     autoscaling/v1's Scale) used to generate an empty file over the shared
+//     package. They're skipped now.
+func TestGenerateFromOpenAPIGoSharedK8sPackages(t *testing.T) {
+	inputFS := afero.NewBasePathFs(afero.FromIOFS{FS: testdataJSONFS}, "testdata")
+	schemaFS, err := goGenerator{}.GenerateFromOpenAPI(t.Context(), inputFS, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The shared apimachinery resource package must define Quantity and must
+	// not import itself.
+	contents, err := afero.ReadFile(schemaFS, "models/io/k8s/resource/v1/resource.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	shared := string(contents)
+	if !strings.Contains(shared, "type Quantity struct") {
+		t.Error("shared resource package no longer defines Quantity")
+	}
+	if strings.Contains(shared, "type Quantity = Quantity") {
+		t.Error("shared resource package contains a self-referential Quantity alias")
+	}
+	if strings.Contains(shared, `"dev.crossplane.io/models/io/k8s/resource/v1"`) {
+		t.Error("shared resource package imports itself")
+	}
+
+	// The resource.k8s.io group models live at io/k8s/api/resource and
+	// reference Quantity from the shared package instead of importing
+	// themselves.
+	contents, err = afero.ReadFile(schemaFS, "models/io/k8s/api/resource/v1/resource.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dra := string(contents)
+	if !strings.Contains(dra, "DeviceClass") {
+		t.Error("resource.k8s.io models are missing DRA types")
+	}
+	if !strings.Contains(dra, "resourcev1.Quantity") {
+		t.Error("resource.k8s.io models don't reference the shared Quantity")
+	}
+
+	// The shared autoscaling package must not be overwritten by the empty
+	// autoscaling/v1 GVK group.
+	contents, err = afero.ReadFile(schemaFS, "models/io/k8s/autoscaling/v1/autoscaling.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), "type Scale") {
+		t.Error("shared autoscaling package no longer defines Scale")
 	}
 }
 
@@ -99,6 +265,7 @@ func TestGenerateFromOpenAPIGo(t *testing.T) {
 		"models/io/k8s/policy/v1/policy.go",
 		"models/io/k8s/autoscaling/v1/autoscaling.go",
 		"models/io/k8s/resource/v1/resource.go",
+		"models/io/k8s/api/resource/v1/resource.go",
 		"models/io/k8s/authentication/v1/authentication.go",
 	}
 
@@ -127,6 +294,7 @@ func TestGenerateFromOpenAPIGo(t *testing.T) {
 			if diff := cmp.Diff(expectedPackage, f.Name.Name); diff != "" {
 				t.Errorf("package name (-want +got):\n%s", diff)
 			}
+			assertValidTypeDecls(t, f, path)
 
 		case ".mod":
 			mod, err := modfile.Parse(path, contents, nil)

--- a/internal/schemas/generator/runtimeobject_compilegate_test.go
+++ b/internal/schemas/generator/runtimeobject_compilegate_test.go
@@ -242,7 +242,8 @@ func TestBuiltInGroupVersions(t *testing.T) {
 	}{
 		"CoreV1":      {obj: &corev1.Pod{}, want: schema.GroupVersionKind{Version: "v1", Kind: "Pod"}},
 		"MetaV1":      {obj: &metav1.Status{}, want: schema.GroupVersionKind{Version: "v1", Kind: "Status"}},
-		"Autoscaling": {obj: &autoscalingv1.TokenRequest{}, want: schema.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "TokenRequest"}},
+		"Autoscaling": {obj: &autoscalingv1.Scale{}, want: schema.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "Scale"}},
+		"Authn":       {obj: &authnv1.TokenRequest{}, want: schema.GroupVersionKind{Group: "authentication.k8s.io", Version: "v1", Kind: "TokenRequest"}},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/schemas/generator/testdata/apis__resource.k8s.io__v1_openapi.json
+++ b/internal/schemas/generator/testdata/apis__resource.k8s.io__v1_openapi.json
@@ -1,0 +1,8887 @@
+{
+  "components": {
+    "schemas": {
+      "io.k8s.api.core.v1.NodeSelector": {
+        "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+        "properties": {
+          "nodeSelectorTerms": {
+            "description": "Required. A list of node selector terms. The terms are ORed.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.NodeSelectorTerm"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "required": [
+          "nodeSelectorTerms"
+        ],
+        "type": "object",
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.api.core.v1.NodeSelectorRequirement": {
+        "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+        "properties": {
+          "key": {
+            "default": "",
+            "description": "The label key that the selector applies to.",
+            "type": "string"
+          },
+          "operator": {
+            "default": "",
+            "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+            "type": "string"
+          },
+          "values": {
+            "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "required": [
+          "key",
+          "operator"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.core.v1.NodeSelectorTerm": {
+        "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+        "properties": {
+          "matchExpressions": {
+            "description": "A list of node selector requirements by node's labels.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.NodeSelectorRequirement"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "matchFields": {
+            "description": "A list of node selector requirements by node's fields.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.core.v1.NodeSelectorRequirement"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "type": "object",
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.api.resource.v1.AllocatedDeviceStatus": {
+        "description": "AllocatedDeviceStatus contains the status of an allocated device, if the driver chooses to report it. This may include driver-specific information.\n\nThe combination of Driver, Pool, Device, and ShareID must match the corresponding key in Status.Allocation.Devices.",
+        "properties": {
+          "conditions": {
+            "description": "Conditions contains the latest observation of the device's state. If the device has been configured according to the class and claim config references, the `Ready` condition should be True.\n\nMust not contain more than 8 entries.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-map-keys": [
+              "type"
+            ],
+            "x-kubernetes-list-type": "map"
+          },
+          "data": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.runtime.RawExtension"
+              }
+            ],
+            "description": "Data contains arbitrary driver-specific data.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
+          },
+          "device": {
+            "default": "",
+            "description": "Device references one device instance via its name in the driver's resource pool. It must be a DNS label.",
+            "type": "string"
+          },
+          "driver": {
+            "default": "",
+            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
+            "type": "string"
+          },
+          "networkData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.NetworkDeviceData"
+              }
+            ],
+            "description": "NetworkData contains network-related information specific to the device."
+          },
+          "pool": {
+            "default": "",
+            "description": "This name together with the driver name and the device name field identify which device was allocated (`<driver name>/<pool name>/<device name>`).\n\nMust not be longer than 253 characters and may contain one or more DNS sub-domains separated by slashes.",
+            "type": "string"
+          },
+          "shareID": {
+            "description": "ShareID uniquely identifies an individual allocation share of the device.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "driver",
+          "pool",
+          "device"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.AllocationResult": {
+        "description": "AllocationResult contains attributes of an allocated resource.",
+        "properties": {
+          "allocationTimestamp": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ],
+            "description": "AllocationTimestamp stores the time when the resources were allocated. This field is not guaranteed to be set, in which case that time is unknown.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gate."
+          },
+          "devices": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceAllocationResult"
+              }
+            ],
+            "default": {},
+            "description": "Devices is the result of allocating devices."
+          },
+          "nodeSelector": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.core.v1.NodeSelector"
+              }
+            ],
+            "description": "NodeSelector defines where the allocated resources are available. If unset, they are available everywhere."
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.CELDeviceSelector": {
+        "description": "CELDeviceSelector contains a CEL expression for selecting a device.",
+        "properties": {
+          "expression": {
+            "default": "",
+            "description": "Expression is a CEL expression which evaluates a single device. It must evaluate to true when the device under consideration satisfies the desired criteria, and false when it does not. Any other result is an error and causes allocation of devices to abort.\n\nThe expression's input is an object named \"device\", which carries the following properties:\n - driver (string): the name of the driver which defines this device.\n - attributes (map[string]object): the device's attributes, grouped by prefix\n   (e.g. device.attributes[\"dra.example.com\"] evaluates to an object with all\n   of the attributes which were prefixed by \"dra.example.com\".\n - capacity (map[string]object): the device's capacities, grouped by prefix.\n - allowMultipleAllocations (bool): the allowMultipleAllocations property of the device\n   (v1.34+ with the DRAConsumableCapacity feature enabled).\n\nExample: Consider a device with driver=\"dra.example.com\", which exposes two attributes named \"model\" and \"ext.example.com/family\" and which exposes one capacity named \"modules\". This input to this expression would have the following fields:\n\n    device.driver\n    device.attributes[\"dra.example.com\"].model\n    device.attributes[\"ext.example.com\"].family\n    device.capacity[\"dra.example.com\"].modules\n\nThe device.driver field can be used to check for a specific driver, either as a high-level precondition (i.e. you only want to consider devices from this driver) or as part of a multi-clause expression that is meant to consider devices from different drivers.\n\nThe value type of each attribute is defined by the device definition, and users who write these expressions must consult the documentation for their specific drivers. The value type of each capacity is Quantity.\n\nIf an unknown prefix is used as a lookup in either device.attributes or device.capacity, an empty map will be returned. Any reference to an unknown field will cause an evaluation error and allocation to abort.\n\nA robust expression should check for the existence of attributes before referencing them.\n\nFor ease of use, the cel.bind() function is enabled, and can be used to simplify expressions that access multiple attributes with the same domain. For example:\n\n    cel.bind(dra, device.attributes[\"dra.example.com\"], dra.someBool && dra.anotherBool)\n\nThe length of the expression must be smaller or equal to 10 Ki. The cost of evaluating it is also limited based on the estimated number of logical steps.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "expression"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.CapacityRequestPolicy": {
+        "description": "CapacityRequestPolicy defines how requests consume device capacity.\n\nMust not set more than one ValidRequestValues.",
+        "properties": {
+          "default": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+              }
+            ],
+            "description": "Default specifies how much of this capacity is consumed by a request that does not contain an entry for it in DeviceRequest's Capacity."
+          },
+          "validRange": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.CapacityRequestPolicyRange"
+              }
+            ],
+            "description": "ValidRange defines an acceptable quantity value range in consuming requests.\n\nIf this field is set, Default must be defined and it must fall within the defined ValidRange.\n\nIf the requested amount does not fall within the defined range, the request violates the policy, and this device cannot be allocated.\n\nIf the request doesn't contain this capacity entry, Default value is used."
+          },
+          "validValues": {
+            "description": "ValidValues defines a set of acceptable quantity values in consuming requests.\n\nMust not contain more than 10 entries. Must be sorted in ascending order.\n\nIf this field is set, Default must be defined and it must be included in ValidValues list.\n\nIf the requested amount does not match any valid value but smaller than some valid values, the scheduler calculates the smallest valid value that is greater than or equal to the request. That is: min(ceil(requestedValue) ∈ validValues), where requestedValue ≤ max(validValues).\n\nIf the requested amount exceeds all valid values, the request violates the policy, and this device cannot be allocated.",
+            "items": {
+              "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.CapacityRequestPolicyRange": {
+        "description": "CapacityRequestPolicyRange defines a valid range for consumable capacity values.\n\n  - If the requested amount is less than Min, it is rounded up to the Min value.\n  - If Step is set and the requested amount is between Min and Max but not aligned with Step,\n    it will be rounded up to the next value equal to Min + (n * Step).\n  - If Step is not set, the requested amount is used as-is if it falls within the range Min to Max (if set).\n  - If the requested or rounded amount exceeds Max (if set), the request does not satisfy the policy,\n    and the device cannot be allocated.",
+        "properties": {
+          "max": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+              }
+            ],
+            "description": "Max defines the upper limit for capacity that can be requested.\n\nMax must be less than or equal to the capacity value. Min and requestPolicy.default must be less than or equal to the maximum."
+          },
+          "min": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+              }
+            ],
+            "description": "Min specifies the minimum capacity allowed for a consumption request.\n\nMin must be greater than or equal to zero, and less than or equal to the capacity value. requestPolicy.default must be more than or equal to the minimum."
+          },
+          "step": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+              }
+            ],
+            "description": "Step defines the step size between valid capacity amounts within the range.\n\nMax (if set) and requestPolicy.default must be a multiple of Step. Min + Step must be less than or equal to the capacity value."
+          }
+        },
+        "required": [
+          "min"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.CapacityRequirements": {
+        "description": "CapacityRequirements defines the capacity requirements for a specific device request.",
+        "properties": {
+          "requests": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            },
+            "description": "Requests represent individual device resource requests for distinct resources, all of which must be provided by the device.\n\nThis value is used as an additional filtering condition against the available capacity on the device. This is semantically equivalent to a CEL selector with `device.capacity[<domain>].<name>.compareTo(quantity(<request quantity>)) >= 0`. For example, device.capacity['test-driver.cdi.k8s.io'].counters.compareTo(quantity('2')) >= 0.\n\nWhen a requestPolicy is defined, the requested amount is adjusted upward to the nearest valid value based on the policy. If the requested amount cannot be adjusted to a valid value—because it exceeds what the requestPolicy allows— the device is considered ineligible for allocation.\n\nFor any capacity that is not explicitly requested: - If no requestPolicy is set, the default consumed capacity is equal to the full device capacity\n  (i.e., the whole device is claimed).\n- If a requestPolicy is set, the default consumed capacity is determined according to that policy.\n\nIf the device allows multiple allocation, the aggregated amount across all requests must not exceed the capacity value. The consumed capacity, which may be adjusted based on the requestPolicy if defined, is recorded in the resource claim’s status.devices[*].consumedCapacity field.",
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.Counter": {
+        "description": "Counter describes a quantity associated with a device.",
+        "properties": {
+          "value": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+              }
+            ],
+            "description": "Value defines how much of a certain device counter is available."
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.CounterSet": {
+        "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourcePool.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+        "properties": {
+          "counters": {
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.Counter"
+                }
+              ],
+              "default": {}
+            },
+            "description": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters is 32.",
+            "type": "object"
+          },
+          "name": {
+            "default": "",
+            "description": "Name defines the name of the counter set. It must be a DNS label.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "counters"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.Device": {
+        "description": "Device represents one individual hardware instance that can be selected based on its attributes. Besides the name, exactly one field must be set.",
+        "properties": {
+          "allNodes": {
+            "description": "AllNodes indicates that all nodes have access to the device.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
+            "type": "boolean"
+          },
+          "allowMultipleAllocations": {
+            "description": "AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.\n\nIf AllowMultipleAllocations is set to true, the device can be allocated more than once, and all of its capacity is consumable, regardless of whether the requestPolicy is defined or not.",
+            "type": "boolean"
+          },
+          "attributes": {
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceAttribute"
+                }
+              ],
+              "default": {}
+            },
+            "description": "Attributes defines the set of attributes for this device. The name of each attribute must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
+            "type": "object"
+          },
+          "bindingConditions": {
+            "description": "BindingConditions defines the conditions for proceeding with binding. All of these conditions must be set in the per-device status conditions with a value of True to proceed with binding the pod to the node while scheduling the pod.\n\nThe maximum number of binding conditions is 4.\n\nThe conditions must be a valid condition type string.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "bindingFailureConditions": {
+            "description": "BindingFailureConditions defines the conditions for binding failure. They may be set in the per-device status conditions. If any is set to \"True\", a binding failure occurred.\n\nThe maximum number of binding failure conditions is 4.\n\nThe conditions must be a valid condition type string.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "bindsToNode": {
+            "description": "BindsToNode indicates if the usage of an allocation involving this device has to be limited to exactly the node that was chosen when allocating the claim. If set to true, the scheduler will set the ResourceClaim.Status.Allocation.NodeSelector to match the node where the allocation was made.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+            "type": "boolean"
+          },
+          "capacity": {
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceCapacity"
+                }
+              ],
+              "default": {}
+            },
+            "description": "Capacity defines the set of capacities for this device. The name of each capacity must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
+            "type": "object"
+          },
+          "consumesCounters": {
+            "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe maximum number of device counter consumptions per device is 2.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceCounterConsumption"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "name": {
+            "default": "",
+            "description": "Name is unique identifier among all devices managed by the driver in the pool. It must be a DNS label.",
+            "type": "string"
+          },
+          "nodeName": {
+            "description": "NodeName identifies the node where the device is available.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
+            "type": "string"
+          },
+          "nodeSelector": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.core.v1.NodeSelector"
+              }
+            ],
+            "description": "NodeSelector defines the nodes where the device is available.\n\nMust use exactly one term.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set."
+          },
+          "taints": {
+            "description": "If specified, these are the driver-defined taints.\n\nThe maximum number of taints is 16. If taints are set for any device in a ResourceSlice, then the maximum number of allowed devices per ResourceSlice is 64 instead of 128.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceTaint"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceAllocationConfiguration": {
+        "description": "DeviceAllocationConfiguration gets embedded in an AllocationResult.",
+        "properties": {
+          "opaque": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.OpaqueDeviceConfiguration"
+              }
+            ],
+            "description": "Opaque provides driver-specific configuration parameters."
+          },
+          "requests": {
+            "description": "Requests lists the names of requests where the configuration applies. If empty, its applies to all requests.\n\nReferences to subrequests must include the name of the main request and may include the subrequest using the format <main request>[/<subrequest>]. If just the main request is given, the configuration applies to all subrequests.",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "source": {
+            "default": "",
+            "description": "Source records whether the configuration comes from a class and thus is not something that a normal user would have been able to set or from a claim.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceAllocationResult": {
+        "description": "DeviceAllocationResult is the result of allocating devices.",
+        "properties": {
+          "config": {
+            "description": "This field is a combination of all the claim and class configuration parameters. Drivers can distinguish between those based on a flag.\n\nThis includes configuration parameters for drivers which have no allocated devices in the result because it is up to the drivers which configuration parameters they support. They can silently ignore unknown configuration parameters.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceAllocationConfiguration"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "results": {
+            "description": "Results lists all allocated devices.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceRequestAllocationResult"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceAttribute": {
+        "description": "DeviceAttribute must have exactly one field set.",
+        "properties": {
+          "bool": {
+            "description": "BoolValue is a true/false value.",
+            "type": "boolean"
+          },
+          "int": {
+            "description": "IntValue is a number.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "string": {
+            "description": "StringValue is a string. Must not be longer than 64 characters.",
+            "type": "string"
+          },
+          "version": {
+            "description": "VersionValue is a semantic version according to semver.org spec 2.0.0. Must not be longer than 64 characters.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceCapacity": {
+        "description": "DeviceCapacity describes a quantity associated with a device.",
+        "properties": {
+          "requestPolicy": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.CapacityRequestPolicy"
+              }
+            ],
+            "description": "RequestPolicy defines how this DeviceCapacity must be consumed when the device is allowed to be shared by multiple allocations.\n\nThe Device must have allowMultipleAllocations set to true in order to set a requestPolicy.\n\nIf unset, capacity requests are unconstrained: requests can consume any amount of capacity, as long as the total consumed across all allocations does not exceed the device's defined capacity. If request is also unset, default is the full capacity value."
+          },
+          "value": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+              }
+            ],
+            "description": "Value defines how much of a certain capacity that device has.\n\nThis field reflects the fixed total capacity and does not change. The consumed amount is tracked separately by scheduler and does not affect this value."
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceClaim": {
+        "description": "DeviceClaim defines how to request devices with a ResourceClaim.",
+        "properties": {
+          "config": {
+            "description": "This field holds configuration for multiple potential drivers which could satisfy requests in this claim. It is ignored while allocating the claim.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClaimConfiguration"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "constraints": {
+            "description": "These constraints must be satisfied by the set of devices that get allocated for the claim.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceConstraint"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "requests": {
+            "description": "Requests represent individual requests for distinct devices which must all be satisfied. If empty, nothing needs to be allocated.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceRequest"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceClaimConfiguration": {
+        "description": "DeviceClaimConfiguration is used for configuration parameters in DeviceClaim.",
+        "properties": {
+          "opaque": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.OpaqueDeviceConfiguration"
+              }
+            ],
+            "description": "Opaque provides driver-specific configuration parameters."
+          },
+          "requests": {
+            "description": "Requests lists the names of requests where the configuration applies. If empty, it applies to all requests.\n\nReferences to subrequests must include the name of the main request and may include the subrequest using the format <main request>[/<subrequest>]. If just the main request is given, the configuration applies to all subrequests.",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceClass": {
+        "description": "DeviceClass is a vendor- or admin-provided resource that contains device configuration and selectors. It can be referenced in the device requests of a claim to apply these presets. Cluster scoped.\n\nThis is an alpha type and requires enabling the DynamicResourceAllocation feature gate.",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+              }
+            ],
+            "default": {},
+            "description": "Standard object metadata"
+          },
+          "spec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClassSpec"
+              }
+            ],
+            "default": {},
+            "description": "Spec defines what can be allocated and how to configure it.\n\nThis is mutable. Consumers have to be prepared for classes changing at any time, either because they get updated or replaced. Claim allocations are done once based on whatever was set in classes at the time of allocation.\n\nChanging the spec automatically increments the metadata.generation number."
+          }
+        },
+        "required": [
+          "spec"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "resource.k8s.io",
+            "kind": "DeviceClass",
+            "version": "v1"
+          }
+        ]
+      },
+      "io.k8s.api.resource.v1.DeviceClassConfiguration": {
+        "description": "DeviceClassConfiguration is used in DeviceClass.",
+        "properties": {
+          "opaque": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.OpaqueDeviceConfiguration"
+              }
+            ],
+            "description": "Opaque provides driver-specific configuration parameters."
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceClassList": {
+        "description": "DeviceClassList is a collection of classes.",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "items": {
+            "description": "Items is the list of resource classes.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+              }
+            ],
+            "default": {},
+            "description": "Standard list metadata"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "resource.k8s.io",
+            "kind": "DeviceClassList",
+            "version": "v1"
+          }
+        ]
+      },
+      "io.k8s.api.resource.v1.DeviceClassSpec": {
+        "description": "DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and how to configure it.",
+        "properties": {
+          "config": {
+            "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClassConfiguration"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "extendedResourceName": {
+            "description": "ExtendedResourceName is the extended resource name for the devices of this class. The devices of this class can be used to satisfy a pod's extended resource requests. It has the same format as the name of a pod's extended resource. It should be unique among all the device classes in a cluster. If two device classes have the same name, then the class created later is picked to satisfy a pod's extended resource requests. If two classes are created at the same time, then the name of the class lexicographically sorted first is picked.\n\nThis is an alpha field.",
+            "type": "string"
+          },
+          "selectors": {
+            "description": "Each selector must be satisfied by a device which is claimed via this class.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceSelector"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceConstraint": {
+        "description": "DeviceConstraint must have exactly one field set besides Requests.",
+        "properties": {
+          "distinctAttribute": {
+            "description": "DistinctAttribute requires that all devices in question have this attribute and that its type and value are unique across those devices.\n\nThis acts as the inverse of MatchAttribute.\n\nThis constraint is used to avoid allocating multiple requests to the same device by ensuring attribute-level differentiation.\n\nThis is useful for scenarios where resource requests must be fulfilled by separate physical devices. For example, a container requests two network interfaces that must be allocated from two different physical NICs.",
+            "type": "string"
+          },
+          "matchAttribute": {
+            "description": "MatchAttribute requires that all devices in question have this attribute and that its type and value are the same across those devices.\n\nFor example, if you specified \"dra.example.com/numa\" (a hypothetical example!), then only devices in the same NUMA node will be chosen. A device which does not have that attribute will not be chosen. All devices should use a value of the same type for this attribute because that is part of its specification, but if one device doesn't, then it also will not be chosen.\n\nMust include the domain qualifier.",
+            "type": "string"
+          },
+          "requests": {
+            "description": "Requests is a list of the one or more requests in this claim which must co-satisfy this constraint. If a request is fulfilled by multiple devices, then all of the devices must satisfy the constraint. If this is not specified, this constraint applies to all requests in this claim.\n\nReferences to subrequests must include the name of the main request and may include the subrequest using the format <main request>[/<subrequest>]. If just the main request is given, the constraint applies to all subrequests.",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceCounterConsumption": {
+        "description": "DeviceCounterConsumption defines a set of counters that a device will consume from a CounterSet.",
+        "properties": {
+          "counterSet": {
+            "default": "",
+            "description": "CounterSet is the name of the set from which the counters defined will be consumed.",
+            "type": "string"
+          },
+          "counters": {
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.Counter"
+                }
+              ],
+              "default": {}
+            },
+            "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number of counters is 32.",
+            "type": "object"
+          }
+        },
+        "required": [
+          "counterSet",
+          "counters"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceRequest": {
+        "description": "DeviceRequest is a request for devices required for a claim. This is typically a request for a single resource like a device, but can also ask for several identical devices. With FirstAvailable it is also possible to provide a prioritized list of requests.",
+        "properties": {
+          "exactly": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ExactDeviceRequest"
+              }
+            ],
+            "description": "Exactly specifies the details for a single request that must be met exactly for the request to be satisfied.\n\nOne of Exactly or FirstAvailable must be set."
+          },
+          "firstAvailable": {
+            "description": "FirstAvailable contains subrequests, of which exactly one will be selected by the scheduler. It tries to satisfy them in the order in which they are listed here. So if there are two entries in the list, the scheduler will only check the second one if it determines that the first one can not be used.\n\nDRA does not yet implement scoring, so the scheduler will select the first set of devices that satisfies all the requests in the claim. And if the requirements can be satisfied on more than one node, other scheduling features will determine which node is chosen. This means that the set of devices allocated to a claim might not be the optimal set available to the cluster. Scoring will be implemented later.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceSubRequest"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "name": {
+            "default": "",
+            "description": "Name can be used to reference this request in a pod.spec.containers[].resources.claims entry and in a constraint of the claim.\n\nReferences using the name in the DeviceRequest will uniquely identify a request when the Exactly field is set. When the FirstAvailable field is set, a reference to the name of the DeviceRequest will match whatever subrequest is chosen by the scheduler.\n\nMust be a DNS label.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceRequestAllocationResult": {
+        "description": "DeviceRequestAllocationResult contains the allocation result for one request.",
+        "properties": {
+          "adminAccess": {
+            "description": "AdminAccess indicates that this device was allocated for administrative access. See the corresponding request field for a definition of mode.\n\nThis is an alpha field and requires enabling the DRAAdminAccess feature gate. Admin access is disabled if this field is unset or set to false, otherwise it is enabled.",
+            "type": "boolean"
+          },
+          "bindingConditions": {
+            "description": "BindingConditions contains a copy of the BindingConditions from the corresponding ResourceSlice at the time of allocation.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "bindingFailureConditions": {
+            "description": "BindingFailureConditions contains a copy of the BindingFailureConditions from the corresponding ResourceSlice at the time of allocation.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "consumedCapacity": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            },
+            "description": "ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request. The consumed amount may differ from the requested amount: it is rounded up to the nearest valid value based on the device’s requestPolicy if applicable (i.e., may not be less than the requested amount).\n\nThe total consumed capacity for each device must not exceed the DeviceCapacity's Value.\n\nThis field is populated only for devices that allow multiple allocations. All capacity entries are included, even if the consumed amount is zero.",
+            "type": "object"
+          },
+          "device": {
+            "default": "",
+            "description": "Device references one device instance via its name in the driver's resource pool. It must be a DNS label.",
+            "type": "string"
+          },
+          "driver": {
+            "default": "",
+            "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
+            "type": "string"
+          },
+          "pool": {
+            "default": "",
+            "description": "This name together with the driver name and the device name field identify which device was allocated (`<driver name>/<pool name>/<device name>`).\n\nMust not be longer than 253 characters and may contain one or more DNS sub-domains separated by slashes.",
+            "type": "string"
+          },
+          "request": {
+            "default": "",
+            "description": "Request is the name of the request in the claim which caused this device to be allocated. If it references a subrequest in the firstAvailable list on a DeviceRequest, this field must include both the name of the main request and the subrequest using the format <main request>/<subrequest>.\n\nMultiple devices may have been allocated per request.",
+            "type": "string"
+          },
+          "shareID": {
+            "description": "ShareID uniquely identifies an individual allocation share of the device, used when the device supports multiple simultaneous allocations. It serves as an additional map key to differentiate concurrent shares of the same device.",
+            "type": "string"
+          },
+          "tolerations": {
+            "description": "A copy of all tolerations specified in the request at the time when the device got allocated.\n\nThe maximum number of tolerations is 16.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceToleration"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "required": [
+          "request",
+          "driver",
+          "pool",
+          "device"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceSelector": {
+        "description": "DeviceSelector must have exactly one field set.",
+        "properties": {
+          "cel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.CELDeviceSelector"
+              }
+            ],
+            "description": "CEL contains a CEL expression for selecting a device."
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceSubRequest": {
+        "description": "DeviceSubRequest describes a request for device provided in the claim.spec.devices.requests[].firstAvailable array. Each is typically a request for a single resource like a device, but can also ask for several identical devices.\n\nDeviceSubRequest is similar to ExactDeviceRequest, but doesn't expose the AdminAccess field as that one is only supported when requesting a specific device.",
+        "properties": {
+          "allocationMode": {
+            "description": "AllocationMode and its related fields define how devices are allocated to satisfy this subrequest. Supported values are:\n\n- ExactCount: This request is for a specific number of devices.\n  This is the default. The exact number is provided in the\n  count field.\n\n- All: This subrequest is for all of the matching devices in a pool.\n  Allocation will fail if some devices are already allocated,\n  unless adminAccess is requested.\n\nIf AllocationMode is not specified, the default mode is ExactCount. If the mode is ExactCount and count is not specified, the default count is one. Any other subrequests must specify this field.\n\nMore modes may get added in the future. Clients must refuse to handle requests with unknown modes.",
+            "type": "string"
+          },
+          "capacity": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.CapacityRequirements"
+              }
+            ],
+            "description": "Capacity define resource requirements against each capacity.\n\nIf this field is unset and the device supports multiple allocations, the default value will be applied to each capacity according to requestPolicy. For the capacity that has no requestPolicy, default is the full capacity value.\n\nApplies to each device allocation. If Count > 1, the request fails if there aren't enough devices that meet the requirements. If AllocationMode is set to All, the request fails if there are devices that otherwise match the request, and have this capacity, with a value >= the requested amount, but which cannot be allocated to this request."
+          },
+          "count": {
+            "description": "Count is used only when the count mode is \"ExactCount\". Must be greater than zero. If AllocationMode is ExactCount and this field is not specified, the default is one.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "deviceClassName": {
+            "default": "",
+            "description": "DeviceClassName references a specific DeviceClass, which can define additional configuration and selectors to be inherited by this subrequest.\n\nA class is required. Which classes are available depends on the cluster.\n\nAdministrators may use this to restrict which devices may get requested by only installing classes with selectors for permitted devices. If users are free to request anything without restrictions, then administrators can create an empty DeviceClass for users to reference.",
+            "type": "string"
+          },
+          "name": {
+            "default": "",
+            "description": "Name can be used to reference this subrequest in the list of constraints or the list of configurations for the claim. References must use the format <main request>/<subrequest>.\n\nMust be a DNS label.",
+            "type": "string"
+          },
+          "selectors": {
+            "description": "Selectors define criteria which must be satisfied by a specific device in order for that device to be considered for this subrequest. All selectors must be satisfied for a device to be considered.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceSelector"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "tolerations": {
+            "description": "If specified, the request's tolerations.\n\nTolerations for NoSchedule are required to allocate a device which has a taint with that effect. The same applies to NoExecute.\n\nIn addition, should any of the allocated devices get tainted with NoExecute after allocation and that effect is not tolerated, then all pods consuming the ResourceClaim get deleted to evict them. The scheduler will not let new pods reserve the claim while it has these tainted devices. Once all pods are evicted, the claim will get deallocated.\n\nThe maximum number of tolerations is 16.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceToleration"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "required": [
+          "name",
+          "deviceClassName"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceTaint": {
+        "description": "The device this taint is attached to has the \"effect\" on any claim which does not tolerate the taint and, through the claim, to pods using the claim.",
+        "properties": {
+          "effect": {
+            "default": "",
+            "description": "The effect of the taint on claims that do not tolerate the taint and through such claims on the pods using them.\n\nValid effects are None, NoSchedule and NoExecute. PreferNoSchedule as used for nodes is not valid here. More effects may get added in the future. Consumers must treat unknown effects like None.",
+            "type": "string"
+          },
+          "key": {
+            "default": "",
+            "description": "The taint key to be applied to a device. Must be a label name.",
+            "type": "string"
+          },
+          "timeAdded": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ],
+            "description": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set."
+          },
+          "value": {
+            "description": "The taint value corresponding to the taint key. Must be a label value.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "effect"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.DeviceToleration": {
+        "description": "The ResourceClaim this DeviceToleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+        "properties": {
+          "effect": {
+            "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule and NoExecute.",
+            "type": "string"
+          },
+          "key": {
+            "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys. Must be a label name.",
+            "type": "string"
+          },
+          "operator": {
+            "default": "Equal",
+            "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a ResourceClaim can tolerate all taints of a particular category.",
+            "type": "string"
+          },
+          "tolerationSeconds": {
+            "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system. If larger than zero, the time when the pod needs to be evicted is calculated as <time when taint was adedd> + <toleration seconds>.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "value": {
+            "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value must be empty, otherwise just a regular string. Must be a label value.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.ExactDeviceRequest": {
+        "description": "ExactDeviceRequest is a request for one or more identical devices.",
+        "properties": {
+          "adminAccess": {
+            "description": "AdminAccess indicates that this is a claim for administrative access to the device(s). Claims with AdminAccess are expected to be used for monitoring or other management services for a device.  They ignore all ordinary claims to the device with respect to access modes and any resource allocations.\n\nThis is an alpha field and requires enabling the DRAAdminAccess feature gate. Admin access is disabled if this field is unset or set to false, otherwise it is enabled.",
+            "type": "boolean"
+          },
+          "allocationMode": {
+            "description": "AllocationMode and its related fields define how devices are allocated to satisfy this request. Supported values are:\n\n- ExactCount: This request is for a specific number of devices.\n  This is the default. The exact number is provided in the\n  count field.\n\n- All: This request is for all of the matching devices in a pool.\n  At least one device must exist on the node for the allocation to succeed.\n  Allocation will fail if some devices are already allocated,\n  unless adminAccess is requested.\n\nIf AllocationMode is not specified, the default mode is ExactCount. If the mode is ExactCount and count is not specified, the default count is one. Any other requests must specify this field.\n\nMore modes may get added in the future. Clients must refuse to handle requests with unknown modes.",
+            "type": "string"
+          },
+          "capacity": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.CapacityRequirements"
+              }
+            ],
+            "description": "Capacity define resource requirements against each capacity.\n\nIf this field is unset and the device supports multiple allocations, the default value will be applied to each capacity according to requestPolicy. For the capacity that has no requestPolicy, default is the full capacity value.\n\nApplies to each device allocation. If Count > 1, the request fails if there aren't enough devices that meet the requirements. If AllocationMode is set to All, the request fails if there are devices that otherwise match the request, and have this capacity, with a value >= the requested amount, but which cannot be allocated to this request."
+          },
+          "count": {
+            "description": "Count is used only when the count mode is \"ExactCount\". Must be greater than zero. If AllocationMode is ExactCount and this field is not specified, the default is one.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "deviceClassName": {
+            "default": "",
+            "description": "DeviceClassName references a specific DeviceClass, which can define additional configuration and selectors to be inherited by this request.\n\nA DeviceClassName is required.\n\nAdministrators may use this to restrict which devices may get requested by only installing classes with selectors for permitted devices. If users are free to request anything without restrictions, then administrators can create an empty DeviceClass for users to reference.",
+            "type": "string"
+          },
+          "selectors": {
+            "description": "Selectors define criteria which must be satisfied by a specific device in order for that device to be considered for this request. All selectors must be satisfied for a device to be considered.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceSelector"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "tolerations": {
+            "description": "If specified, the request's tolerations.\n\nTolerations for NoSchedule are required to allocate a device which has a taint with that effect. The same applies to NoExecute.\n\nIn addition, should any of the allocated devices get tainted with NoExecute after allocation and that effect is not tolerated, then all pods consuming the ResourceClaim get deleted to evict them. The scheduler will not let new pods reserve the claim while it has these tainted devices. Once all pods are evicted, the claim will get deallocated.\n\nThe maximum number of tolerations is 16.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceToleration"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "required": [
+          "deviceClassName"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.NetworkDeviceData": {
+        "description": "NetworkDeviceData provides network-related details for the allocated device. This information may be filled by drivers or other components to configure or identify the device within a network context.",
+        "properties": {
+          "hardwareAddress": {
+            "description": "HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.\n\nMust not be longer than 128 characters.",
+            "type": "string"
+          },
+          "interfaceName": {
+            "description": "InterfaceName specifies the name of the network interface associated with the allocated device. This might be the name of a physical or virtual network interface being configured in the pod.\n\nMust not be longer than 256 characters.",
+            "type": "string"
+          },
+          "ips": {
+            "description": "IPs lists the network addresses assigned to the device's network interface. This can include both IPv4 and IPv6 addresses. The IPs are in the CIDR notation, which includes both the address and the associated subnet mask. e.g.: \"192.0.2.5/24\" for IPv4 and \"2001:db8::5/64\" for IPv6.",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.OpaqueDeviceConfiguration": {
+        "description": "OpaqueDeviceConfiguration contains configuration parameters for a driver in a format defined by the driver vendor.",
+        "properties": {
+          "driver": {
+            "default": "",
+            "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
+            "type": "string"
+          },
+          "parameters": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.runtime.RawExtension"
+              }
+            ],
+            "description": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
+          }
+        },
+        "required": [
+          "driver",
+          "parameters"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.ResourceClaim": {
+        "description": "ResourceClaim describes a request for access to resources in the cluster, for use by workloads. For example, if a workload needs an accelerator device with specific properties, this is how that request is expressed. The status stanza tracks whether this claim has been satisfied and what specific resources have been allocated.\n\nThis is an alpha type and requires enabling the DynamicResourceAllocation feature gate.",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+              }
+            ],
+            "default": {},
+            "description": "Standard object metadata"
+          },
+          "spec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimSpec"
+              }
+            ],
+            "default": {},
+            "description": "Spec describes what is being requested and how to configure it. The spec is immutable."
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimStatus"
+              }
+            ],
+            "default": {},
+            "description": "Status describes whether the claim is ready to use and what has been allocated."
+          }
+        },
+        "required": [
+          "spec"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "resource.k8s.io",
+            "kind": "ResourceClaim",
+            "version": "v1"
+          }
+        ]
+      },
+      "io.k8s.api.resource.v1.ResourceClaimConsumerReference": {
+        "description": "ResourceClaimConsumerReference contains enough information to let you locate the consumer of a ResourceClaim. The user must be a resource in the same namespace as the ResourceClaim.",
+        "properties": {
+          "apiGroup": {
+            "description": "APIGroup is the group for the resource being referenced. It is empty for the core API. This matches the group in the APIVersion that is used when creating the resources.",
+            "type": "string"
+          },
+          "name": {
+            "default": "",
+            "description": "Name is the name of resource being referenced.",
+            "type": "string"
+          },
+          "resource": {
+            "default": "",
+            "description": "Resource is the type of resource being referenced, for example \"pods\".",
+            "type": "string"
+          },
+          "uid": {
+            "default": "",
+            "description": "UID identifies exactly one incarnation of the resource.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "resource",
+          "name",
+          "uid"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.ResourceClaimList": {
+        "description": "ResourceClaimList is a collection of claims.",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "items": {
+            "description": "Items is the list of resource claims.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+              }
+            ],
+            "default": {},
+            "description": "Standard list metadata"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "resource.k8s.io",
+            "kind": "ResourceClaimList",
+            "version": "v1"
+          }
+        ]
+      },
+      "io.k8s.api.resource.v1.ResourceClaimSpec": {
+        "description": "ResourceClaimSpec defines what is being requested in a ResourceClaim and how to configure it.",
+        "properties": {
+          "devices": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClaim"
+              }
+            ],
+            "default": {},
+            "description": "Devices defines how to request devices."
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.ResourceClaimStatus": {
+        "description": "ResourceClaimStatus tracks whether the resource has been allocated and what the result of that was.",
+        "properties": {
+          "allocation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.AllocationResult"
+              }
+            ],
+            "description": "Allocation is set once the claim has been allocated successfully."
+          },
+          "devices": {
+            "description": "Devices contains the status of each device allocated for this claim, as reported by the driver. This can include driver-specific information. Entries are owned by their respective drivers.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.AllocatedDeviceStatus"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-map-keys": [
+              "driver",
+              "device",
+              "pool",
+              "shareID"
+            ],
+            "x-kubernetes-list-type": "map"
+          },
+          "reservedFor": {
+            "description": "ReservedFor indicates which entities are currently allowed to use the claim. A Pod which references a ResourceClaim which is not reserved for that Pod will not be started. A claim that is in use or might be in use because it has been reserved must not get deallocated.\n\nIn a cluster with multiple scheduler instances, two pods might get scheduled concurrently by different schedulers. When they reference the same ResourceClaim which already has reached its maximum number of consumers, only one pod can be scheduled.\n\nBoth schedulers try to add their pod to the claim.status.reservedFor field, but only the update that reaches the API server first gets stored. The other one fails with an error and the scheduler which issued it knows that it must put the pod back into the queue, waiting for the ResourceClaim to become usable again.\n\nThere can be at most 256 such reservations. This may get increased in the future, but not reduced.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimConsumerReference"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-map-keys": [
+              "uid"
+            ],
+            "x-kubernetes-list-type": "map",
+            "x-kubernetes-patch-merge-key": "uid",
+            "x-kubernetes-patch-strategy": "merge"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.ResourceClaimTemplate": {
+        "description": "ResourceClaimTemplate is used to produce ResourceClaim objects.\n\nThis is an alpha type and requires enabling the DynamicResourceAllocation feature gate.",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+              }
+            ],
+            "default": {},
+            "description": "Standard object metadata"
+          },
+          "spec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateSpec"
+              }
+            ],
+            "default": {},
+            "description": "Describes the ResourceClaim that is to be generated.\n\nThis field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore."
+          }
+        },
+        "required": [
+          "spec"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "resource.k8s.io",
+            "kind": "ResourceClaimTemplate",
+            "version": "v1"
+          }
+        ]
+      },
+      "io.k8s.api.resource.v1.ResourceClaimTemplateList": {
+        "description": "ResourceClaimTemplateList is a collection of claim templates.",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "items": {
+            "description": "Items is the list of resource claim templates.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+              }
+            ],
+            "default": {},
+            "description": "Standard list metadata"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "resource.k8s.io",
+            "kind": "ResourceClaimTemplateList",
+            "version": "v1"
+          }
+        ]
+      },
+      "io.k8s.api.resource.v1.ResourceClaimTemplateSpec": {
+        "description": "ResourceClaimTemplateSpec contains the metadata and fields for a ResourceClaim.",
+        "properties": {
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+              }
+            ],
+            "default": {},
+            "description": "ObjectMeta may contain labels and annotations that will be copied into the ResourceClaim when creating it. No other fields are allowed and will be rejected during validation."
+          },
+          "spec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimSpec"
+              }
+            ],
+            "default": {},
+            "description": "Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here."
+          }
+        },
+        "required": [
+          "spec"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.ResourcePool": {
+        "description": "ResourcePool describes the pool that ResourceSlices belong to.",
+        "properties": {
+          "generation": {
+            "default": 0,
+            "description": "Generation tracks the change in a pool over time. Whenever a driver changes something about one or more of the resources in a pool, it must change the generation in all ResourceSlices which are part of that pool. Consumers of ResourceSlices should only consider resources from the pool with the highest generation number. The generation may be reset by drivers, which should be fine for consumers, assuming that all ResourceSlices in a pool are updated to match or deleted.\n\nCombined with ResourceSliceCount, this mechanism enables consumers to detect pools which are comprised of multiple ResourceSlices and are in an incomplete state.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "default": "",
+            "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+            "type": "string"
+          },
+          "resourceSliceCount": {
+            "default": 0,
+            "description": "ResourceSliceCount is the total number of ResourceSlices in the pool at this generation number. Must be greater than zero.\n\nConsumers can use this to check whether they have seen all ResourceSlices belonging to the same pool.",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "generation",
+          "resourceSliceCount"
+        ],
+        "type": "object"
+      },
+      "io.k8s.api.resource.v1.ResourceSlice": {
+        "description": "ResourceSlice represents one or more resources in a pool of similar resources, managed by a common driver. A pool may span more than one ResourceSlice, and exactly how many ResourceSlices comprise a pool is determined by the driver.\n\nAt the moment, the only supported resources are devices with attributes and capacities. Each device in a given pool, regardless of how many ResourceSlices, must have a unique name. The ResourceSlice in which a device gets published may change over time. The unique identifier for a device is the tuple <driver name>, <pool name>, <device name>.\n\nWhenever a driver needs to update a pool, it increments the pool.Spec.Pool.Generation number and updates all ResourceSlices with that new number and new resource definitions. A consumer must only use ResourceSlices with the highest generation number and ignore all others.\n\nWhen allocating all resources in a pool matching certain criteria or when looking for the best solution among several different alternatives, a consumer should check the number of ResourceSlices in a pool (included in each ResourceSlice) to determine whether its view of a pool is complete and if not, should wait until the driver has completed updating the pool.\n\nFor resources that are not local to a node, the node name is not set. Instead, the driver may use a node selector to specify where the devices are available.\n\nThis is an alpha type and requires enabling the DynamicResourceAllocation feature gate.",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+              }
+            ],
+            "default": {},
+            "description": "Standard object metadata"
+          },
+          "spec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSliceSpec"
+              }
+            ],
+            "default": {},
+            "description": "Contains the information published by the driver.\n\nChanging the spec automatically increments the metadata.generation number."
+          }
+        },
+        "required": [
+          "spec"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "resource.k8s.io",
+            "kind": "ResourceSlice",
+            "version": "v1"
+          }
+        ]
+      },
+      "io.k8s.api.resource.v1.ResourceSliceList": {
+        "description": "ResourceSliceList is a collection of ResourceSlices.",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "items": {
+            "description": "Items is the list of resource ResourceSlices.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+              }
+            ],
+            "default": {},
+            "description": "Standard list metadata"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "resource.k8s.io",
+            "kind": "ResourceSliceList",
+            "version": "v1"
+          }
+        ]
+      },
+      "io.k8s.api.resource.v1.ResourceSliceSpec": {
+        "description": "ResourceSliceSpec contains the information published by the driver in one ResourceSlice.",
+        "properties": {
+          "allNodes": {
+            "description": "AllNodes indicates that all nodes have access to the resources in the pool.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",
+            "type": "boolean"
+          },
+          "devices": {
+            "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries. If any device uses taints or consumes counters the limit is 64.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.Device"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "driver": {
+            "default": "",
+            "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
+            "type": "string"
+          },
+          "nodeName": {
+            "description": "NodeName identifies the node which provides the resources in this pool. A field selector can be used to list only ResourceSlice objects belonging to a certain node.\n\nThis field can be used to limit access from nodes to ResourceSlices with the same node name. It also indicates to autoscalers that adding new nodes of the same type as some old node might also make new resources available.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set. This field is immutable.",
+            "type": "string"
+          },
+          "nodeSelector": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.core.v1.NodeSelector"
+              }
+            ],
+            "description": "NodeSelector defines which nodes have access to the resources in the pool, when that pool is not limited to a single node.\n\nMust use exactly one term.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set."
+          },
+          "perDeviceNodeSelection": {
+            "description": "PerDeviceNodeSelection defines whether the access from nodes to resources in the pool is set on the ResourceSlice level or on each device. If it is set to true, every device defined the ResourceSlice must specify this individually.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",
+            "type": "boolean"
+          },
+          "pool": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourcePool"
+              }
+            ],
+            "default": {},
+            "description": "Pool describes the pool that this ResourceSlice belongs to."
+          },
+          "sharedCounters": {
+            "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the counter sets must be unique in the ResourcePool.\n\nOnly one of Devices and SharedCounters can be set in a ResourceSlice.\n\nThe maximum number of counter sets is 8.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.CounterSet"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "required": [
+          "driver",
+          "pool"
+        ],
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.api.resource.Quantity": {
+        "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
+        "description": "APIResource specifies the name of a resource and whether it is namespaced.",
+        "properties": {
+          "categories": {
+            "description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "group": {
+            "description": "group is the preferred group of the resource.  Empty implies the group of the containing resource list. For subresources, this may have a different value, for example: Scale\".",
+            "type": "string"
+          },
+          "kind": {
+            "default": "",
+            "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
+            "type": "string"
+          },
+          "name": {
+            "default": "",
+            "description": "name is the plural name of the resource.",
+            "type": "string"
+          },
+          "namespaced": {
+            "default": false,
+            "description": "namespaced indicates if a resource is namespaced or not.",
+            "type": "boolean"
+          },
+          "shortNames": {
+            "description": "shortNames is a list of suggested short names of the resource.",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "singularName": {
+            "default": "",
+            "description": "singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.",
+            "type": "string"
+          },
+          "storageVersionHash": {
+            "description": "The hash value of the storage version, the version this resource is converted to when written to the data store. Value must be treated as opaque by clients. Only equality comparison on the value is valid. This is an alpha feature and may change or be removed in the future. The field is populated by the apiserver only if the StorageVersionHash feature gate is enabled. This field will remain optional even if it graduates.",
+            "type": "string"
+          },
+          "verbs": {
+            "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "version is the preferred version of the resource.  Empty implies the version of the containing resource list For subresources, this may have a different value, for example: v1 (while inside a v1beta1 version of the core resource's group)\".",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "singularName",
+          "namespaced",
+          "kind",
+          "verbs"
+        ],
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+        "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "groupVersion": {
+            "default": "",
+            "description": "groupVersion is the group and version this APIResourceList is for.",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "resources": {
+            "description": "resources contains the name of the resources and if they are namespaced.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          }
+        },
+        "required": [
+          "groupVersion",
+          "resources"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "",
+            "kind": "APIResourceList",
+            "version": "v1"
+          }
+        ]
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+        "description": "Condition contains details for one aspect of the current state of this API Resource.",
+        "properties": {
+          "lastTransitionTime": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ],
+            "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable."
+          },
+          "message": {
+            "default": "",
+            "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+            "type": "string"
+          },
+          "observedGeneration": {
+            "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "reason": {
+            "default": "",
+            "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+            "type": "string"
+          },
+          "status": {
+            "default": "",
+            "description": "status of the condition, one of True, False, Unknown.",
+            "type": "string"
+          },
+          "type": {
+            "default": "",
+            "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "status",
+          "lastTransitionTime",
+          "reason",
+          "message"
+        ],
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+        "description": "DeleteOptions may be provided when deleting an API object.",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "dryRun": {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "gracePeriodSeconds": {
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "ignoreStoreReadErrorWithClusterBreakingPotential": {
+            "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+            "type": "boolean"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "orphanDependents": {
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "type": "boolean"
+          },
+          "preconditions": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
+              }
+            ],
+            "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned."
+          },
+          "propagationPolicy": {
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "admission.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "admission.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "admissionregistration.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "admissionregistration.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "admissionregistration.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "apiextensions.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "apiextensions.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "apiregistration.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "apiregistration.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "apps",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "apps",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "apps",
+            "kind": "DeleteOptions",
+            "version": "v1beta2"
+          },
+          {
+            "group": "authentication.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "authentication.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "authentication.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "authorization.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "authorization.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "autoscaling",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "autoscaling",
+            "kind": "DeleteOptions",
+            "version": "v2"
+          },
+          {
+            "group": "autoscaling",
+            "kind": "DeleteOptions",
+            "version": "v2beta1"
+          },
+          {
+            "group": "autoscaling",
+            "kind": "DeleteOptions",
+            "version": "v2beta2"
+          },
+          {
+            "group": "batch",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "batch",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "certificates.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "certificates.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "certificates.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "coordination.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "coordination.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha2"
+          },
+          {
+            "group": "coordination.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "discovery.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "discovery.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "events.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "events.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "extensions",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta2"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta3"
+          },
+          {
+            "group": "imagepolicy.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "internal.apiserver.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "networking.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "networking.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "node.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "node.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "node.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "policy",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "policy",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "rbac.authorization.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "rbac.authorization.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "rbac.authorization.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "resource.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "resource.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha3"
+          },
+          {
+            "group": "resource.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "resource.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta2"
+          },
+          {
+            "group": "scheduling.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "scheduling.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "scheduling.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "storage.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1"
+          },
+          {
+            "group": "storage.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "storage.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          },
+          {
+            "group": "storagemigration.k8s.io",
+            "kind": "DeleteOptions",
+            "version": "v1beta1"
+          }
+        ]
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+        "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
+        "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+        "properties": {
+          "continue": {
+            "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+            "type": "string"
+          },
+          "remainingItemCount": {
+            "description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "resourceVersion": {
+            "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+            "type": "string"
+          },
+          "selfLink": {
+            "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+        "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+            "type": "string"
+          },
+          "fieldsType": {
+            "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+            "type": "string"
+          },
+          "fieldsV1": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1"
+              }
+            ],
+            "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type."
+          },
+          "manager": {
+            "description": "Manager is an identifier of the workflow managing these fields.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+            "type": "string"
+          },
+          "subresource": {
+            "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+            "type": "string"
+          },
+          "time": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ],
+            "description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over."
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+        "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+        "properties": {
+          "annotations": {
+            "additionalProperties": {
+              "default": "",
+              "type": "string"
+            },
+            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+            "type": "object"
+          },
+          "creationTimestamp": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ],
+            "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+          },
+          "deletionGracePeriodSeconds": {
+            "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "deletionTimestamp": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ],
+            "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+          },
+          "finalizers": {
+            "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+            "items": {
+              "default": "",
+              "type": "string"
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "set",
+            "x-kubernetes-patch-strategy": "merge"
+          },
+          "generateName": {
+            "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+            "type": "string"
+          },
+          "generation": {
+            "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "labels": {
+            "additionalProperties": {
+              "default": "",
+              "type": "string"
+            },
+            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+            "type": "object"
+          },
+          "managedFields": {
+            "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "name": {
+            "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+            "type": "string"
+          },
+          "namespace": {
+            "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces",
+            "type": "string"
+          },
+          "ownerReferences": {
+            "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-map-keys": [
+              "uid"
+            ],
+            "x-kubernetes-list-type": "map",
+            "x-kubernetes-patch-merge-key": "uid",
+            "x-kubernetes-patch-strategy": "merge"
+          },
+          "resourceVersion": {
+            "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+            "type": "string"
+          },
+          "selfLink": {
+            "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+            "type": "string"
+          },
+          "uid": {
+            "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+        "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+        "properties": {
+          "apiVersion": {
+            "default": "",
+            "description": "API version of the referent.",
+            "type": "string"
+          },
+          "blockOwnerDeletion": {
+            "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+            "type": "boolean"
+          },
+          "controller": {
+            "description": "If true, this reference points to the managing controller.",
+            "type": "boolean"
+          },
+          "kind": {
+            "default": "",
+            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "name": {
+            "default": "",
+            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+            "type": "string"
+          },
+          "uid": {
+            "default": "",
+            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+            "type": "string"
+          }
+        },
+        "required": [
+          "apiVersion",
+          "kind",
+          "name",
+          "uid"
+        ],
+        "type": "object",
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
+        "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
+        "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+        "properties": {
+          "resourceVersion": {
+            "description": "Specifies the target ResourceVersion",
+            "type": "string"
+          },
+          "uid": {
+            "description": "Specifies the target UID.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+        "description": "Status is a return value for calls that don't return other objects.",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "code": {
+            "description": "Suggested HTTP return code for this status, 0 if not set.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "details": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
+              }
+            ],
+            "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "message": {
+            "description": "A human-readable description of the status of this operation.",
+            "type": "string"
+          },
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+              }
+            ],
+            "default": {},
+            "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+          },
+          "reason": {
+            "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+            "type": "string"
+          },
+          "status": {
+            "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "",
+            "kind": "Status",
+            "version": "v1"
+          }
+        ]
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
+        "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+        "properties": {
+          "field": {
+            "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+            "type": "string"
+          },
+          "message": {
+            "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+            "type": "string"
+          },
+          "reason": {
+            "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+        "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+        "properties": {
+          "causes": {
+            "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+                }
+              ],
+              "default": {}
+            },
+            "type": "array",
+            "x-kubernetes-list-type": "atomic"
+          },
+          "group": {
+            "description": "The group attribute of the resource associated with the status StatusReason.",
+            "type": "string"
+          },
+          "kind": {
+            "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+            "type": "string"
+          },
+          "retryAfterSeconds": {
+            "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "uid": {
+            "description": "UID of the resource. (when there is a single resource which can be described). More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+        "format": "date-time",
+        "type": "string"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+        "description": "Event represents a single event to a watched resource.",
+        "properties": {
+          "object": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.runtime.RawExtension"
+              }
+            ],
+            "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context."
+          },
+          "type": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "object"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "admission.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "admission.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "admissionregistration.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "admissionregistration.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "admissionregistration.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "apiextensions.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "apiextensions.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "apiregistration.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "apiregistration.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "apps",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "apps",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "apps",
+            "kind": "WatchEvent",
+            "version": "v1beta2"
+          },
+          {
+            "group": "authentication.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "authentication.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "authentication.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "authorization.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "authorization.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "autoscaling",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "autoscaling",
+            "kind": "WatchEvent",
+            "version": "v2"
+          },
+          {
+            "group": "autoscaling",
+            "kind": "WatchEvent",
+            "version": "v2beta1"
+          },
+          {
+            "group": "autoscaling",
+            "kind": "WatchEvent",
+            "version": "v2beta2"
+          },
+          {
+            "group": "batch",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "batch",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "certificates.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "certificates.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "certificates.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "coordination.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "coordination.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha2"
+          },
+          {
+            "group": "coordination.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "discovery.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "discovery.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "events.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "events.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "extensions",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta2"
+          },
+          {
+            "group": "flowcontrol.apiserver.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta3"
+          },
+          {
+            "group": "imagepolicy.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "internal.apiserver.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "networking.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "networking.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "node.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "node.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "node.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "policy",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "policy",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "rbac.authorization.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "rbac.authorization.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "rbac.authorization.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "resource.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "resource.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha3"
+          },
+          {
+            "group": "resource.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "resource.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta2"
+          },
+          {
+            "group": "scheduling.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "scheduling.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "scheduling.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "storage.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1"
+          },
+          {
+            "group": "storage.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1alpha1"
+          },
+          {
+            "group": "storage.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          },
+          {
+            "group": "storagemigration.k8s.io",
+            "kind": "WatchEvent",
+            "version": "v1beta1"
+          }
+        ]
+      },
+      "io.k8s.apimachinery.pkg.runtime.RawExtension": {
+        "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package:\n\n\ttype MyAPIObject struct {\n\t\truntime.TypeMeta `json:\",inline\"`\n\t\tMyPlugin runtime.Object `json:\"myPlugin\"`\n\t}\n\n\ttype PluginA struct {\n\t\tAOption string `json:\"aOption\"`\n\t}\n\n// External package:\n\n\ttype MyAPIObject struct {\n\t\truntime.TypeMeta `json:\",inline\"`\n\t\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n\t}\n\n\ttype PluginA struct {\n\t\tAOption string `json:\"aOption\"`\n\t}\n\n// On the wire, the JSON will look something like this:\n\n\t{\n\t\t\"kind\":\"MyAPIObject\",\n\t\t\"apiVersion\":\"v1\",\n\t\t\"myPlugin\": {\n\t\t\t\"kind\":\"PluginA\",\n\t\t\t\"aOption\":\"foo\",\n\t\t},\n\t}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "BearerToken": {
+        "description": "Bearer Token authentication",
+        "in": "header",
+        "name": "authorization",
+        "type": "apiKey"
+      }
+    }
+  },
+  "info": {
+    "title": "Kubernetes",
+    "version": "unversioned"
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/apis/resource.k8s.io/v1/": {
+      "get": {
+        "description": "get available resources",
+        "operationId": "getResourceV1APIResources",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ]
+      }
+    },
+    "/apis/resource.k8s.io/v1/deviceclasses": {
+      "delete": {
+        "description": "delete collection of DeviceClass",
+        "operationId": "deleteResourceV1CollectionDeviceClass",
+        "parameters": [
+          {
+            "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+            "in": "query",
+            "name": "continue",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+            "in": "query",
+            "name": "fieldSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "in": "query",
+            "name": "gracePeriodSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+            "in": "query",
+            "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+            "in": "query",
+            "name": "labelSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "in": "query",
+            "name": "orphanDependents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "in": "query",
+            "name": "propagationPolicy",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersion",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersionMatch",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+            "in": "query",
+            "name": "sendInitialEvents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+            "in": "query",
+            "name": "timeoutSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "deletecollection",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "DeviceClass",
+          "version": "v1"
+        }
+      },
+      "get": {
+        "description": "list or watch objects of kind DeviceClass",
+        "operationId": "listResourceV1DeviceClass",
+        "parameters": [
+          {
+            "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+            "in": "query",
+            "name": "allowWatchBookmarks",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+            "in": "query",
+            "name": "continue",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+            "in": "query",
+            "name": "fieldSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+            "in": "query",
+            "name": "labelSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersion",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersionMatch",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+            "in": "query",
+            "name": "sendInitialEvents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+            "in": "query",
+            "name": "timeoutSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+            "in": "query",
+            "name": "watch",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClassList"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClassList"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClassList"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClassList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClassList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClassList"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClassList"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "list",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "DeviceClass",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ],
+      "post": {
+        "description": "create a DeviceClass",
+        "operationId": "createResourceV1DeviceClass",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "202": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "post",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "DeviceClass",
+          "version": "v1"
+        }
+      }
+    },
+    "/apis/resource.k8s.io/v1/deviceclasses/{name}": {
+      "delete": {
+        "description": "delete a DeviceClass",
+        "operationId": "deleteResourceV1DeviceClass",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "in": "query",
+            "name": "gracePeriodSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+            "in": "query",
+            "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "in": "query",
+            "name": "orphanDependents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "in": "query",
+            "name": "propagationPolicy",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "202": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "delete",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "DeviceClass",
+          "version": "v1"
+        }
+      },
+      "get": {
+        "description": "read the specified DeviceClass",
+        "operationId": "readResourceV1DeviceClass",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "DeviceClass",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "name of the DeviceClass",
+          "in": "path",
+          "name": "name",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ],
+      "patch": {
+        "description": "partially update the specified DeviceClass",
+        "operationId": "patchResourceV1DeviceClass",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/apply-patch+yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/strategic-merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "patch",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "DeviceClass",
+          "version": "v1"
+        }
+      },
+      "put": {
+        "description": "replace the specified DeviceClass",
+        "operationId": "replaceResourceV1DeviceClass",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClass"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "put",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "DeviceClass",
+          "version": "v1"
+        }
+      }
+    },
+    "/apis/resource.k8s.io/v1/namespaces/{namespace}/resourceclaims": {
+      "delete": {
+        "description": "delete collection of ResourceClaim",
+        "operationId": "deleteResourceV1CollectionNamespacedResourceClaim",
+        "parameters": [
+          {
+            "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+            "in": "query",
+            "name": "continue",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+            "in": "query",
+            "name": "fieldSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "in": "query",
+            "name": "gracePeriodSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+            "in": "query",
+            "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+            "in": "query",
+            "name": "labelSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "in": "query",
+            "name": "orphanDependents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "in": "query",
+            "name": "propagationPolicy",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersion",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersionMatch",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+            "in": "query",
+            "name": "sendInitialEvents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+            "in": "query",
+            "name": "timeoutSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "deletecollection",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      },
+      "get": {
+        "description": "list or watch objects of kind ResourceClaim",
+        "operationId": "listResourceV1NamespacedResourceClaim",
+        "parameters": [
+          {
+            "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+            "in": "query",
+            "name": "allowWatchBookmarks",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+            "in": "query",
+            "name": "continue",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+            "in": "query",
+            "name": "fieldSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+            "in": "query",
+            "name": "labelSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersion",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersionMatch",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+            "in": "query",
+            "name": "sendInitialEvents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+            "in": "query",
+            "name": "timeoutSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+            "in": "query",
+            "name": "watch",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "list",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "object name and auth scope, such as for teams and projects",
+          "in": "path",
+          "name": "namespace",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ],
+      "post": {
+        "description": "create a ResourceClaim",
+        "operationId": "createResourceV1NamespacedResourceClaim",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "202": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "post",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      }
+    },
+    "/apis/resource.k8s.io/v1/namespaces/{namespace}/resourceclaims/{name}": {
+      "delete": {
+        "description": "delete a ResourceClaim",
+        "operationId": "deleteResourceV1NamespacedResourceClaim",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "in": "query",
+            "name": "gracePeriodSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+            "in": "query",
+            "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "in": "query",
+            "name": "orphanDependents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "in": "query",
+            "name": "propagationPolicy",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "202": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "delete",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      },
+      "get": {
+        "description": "read the specified ResourceClaim",
+        "operationId": "readResourceV1NamespacedResourceClaim",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "name of the ResourceClaim",
+          "in": "path",
+          "name": "name",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "object name and auth scope, such as for teams and projects",
+          "in": "path",
+          "name": "namespace",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ],
+      "patch": {
+        "description": "partially update the specified ResourceClaim",
+        "operationId": "patchResourceV1NamespacedResourceClaim",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/apply-patch+yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/strategic-merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "patch",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      },
+      "put": {
+        "description": "replace the specified ResourceClaim",
+        "operationId": "replaceResourceV1NamespacedResourceClaim",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "put",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      }
+    },
+    "/apis/resource.k8s.io/v1/namespaces/{namespace}/resourceclaims/{name}/status": {
+      "get": {
+        "description": "read status of the specified ResourceClaim",
+        "operationId": "readResourceV1NamespacedResourceClaimStatus",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "name of the ResourceClaim",
+          "in": "path",
+          "name": "name",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "object name and auth scope, such as for teams and projects",
+          "in": "path",
+          "name": "namespace",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ],
+      "patch": {
+        "description": "partially update status of the specified ResourceClaim",
+        "operationId": "patchResourceV1NamespacedResourceClaimStatus",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/apply-patch+yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/strategic-merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "patch",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      },
+      "put": {
+        "description": "replace status of the specified ResourceClaim",
+        "operationId": "replaceResourceV1NamespacedResourceClaimStatus",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaim"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "put",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      }
+    },
+    "/apis/resource.k8s.io/v1/namespaces/{namespace}/resourceclaimtemplates": {
+      "delete": {
+        "description": "delete collection of ResourceClaimTemplate",
+        "operationId": "deleteResourceV1CollectionNamespacedResourceClaimTemplate",
+        "parameters": [
+          {
+            "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+            "in": "query",
+            "name": "continue",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+            "in": "query",
+            "name": "fieldSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "in": "query",
+            "name": "gracePeriodSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+            "in": "query",
+            "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+            "in": "query",
+            "name": "labelSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "in": "query",
+            "name": "orphanDependents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "in": "query",
+            "name": "propagationPolicy",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersion",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersionMatch",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+            "in": "query",
+            "name": "sendInitialEvents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+            "in": "query",
+            "name": "timeoutSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "deletecollection",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimTemplate",
+          "version": "v1"
+        }
+      },
+      "get": {
+        "description": "list or watch objects of kind ResourceClaimTemplate",
+        "operationId": "listResourceV1NamespacedResourceClaimTemplate",
+        "parameters": [
+          {
+            "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+            "in": "query",
+            "name": "allowWatchBookmarks",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+            "in": "query",
+            "name": "continue",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+            "in": "query",
+            "name": "fieldSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+            "in": "query",
+            "name": "labelSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersion",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersionMatch",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+            "in": "query",
+            "name": "sendInitialEvents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+            "in": "query",
+            "name": "timeoutSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+            "in": "query",
+            "name": "watch",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "list",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimTemplate",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "object name and auth scope, such as for teams and projects",
+          "in": "path",
+          "name": "namespace",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ],
+      "post": {
+        "description": "create a ResourceClaimTemplate",
+        "operationId": "createResourceV1NamespacedResourceClaimTemplate",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "202": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "post",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimTemplate",
+          "version": "v1"
+        }
+      }
+    },
+    "/apis/resource.k8s.io/v1/namespaces/{namespace}/resourceclaimtemplates/{name}": {
+      "delete": {
+        "description": "delete a ResourceClaimTemplate",
+        "operationId": "deleteResourceV1NamespacedResourceClaimTemplate",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "in": "query",
+            "name": "gracePeriodSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+            "in": "query",
+            "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "in": "query",
+            "name": "orphanDependents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "in": "query",
+            "name": "propagationPolicy",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "202": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "delete",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimTemplate",
+          "version": "v1"
+        }
+      },
+      "get": {
+        "description": "read the specified ResourceClaimTemplate",
+        "operationId": "readResourceV1NamespacedResourceClaimTemplate",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimTemplate",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "name of the ResourceClaimTemplate",
+          "in": "path",
+          "name": "name",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "object name and auth scope, such as for teams and projects",
+          "in": "path",
+          "name": "namespace",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ],
+      "patch": {
+        "description": "partially update the specified ResourceClaimTemplate",
+        "operationId": "patchResourceV1NamespacedResourceClaimTemplate",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/apply-patch+yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/strategic-merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "patch",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimTemplate",
+          "version": "v1"
+        }
+      },
+      "put": {
+        "description": "replace the specified ResourceClaimTemplate",
+        "operationId": "replaceResourceV1NamespacedResourceClaimTemplate",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplate"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "put",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimTemplate",
+          "version": "v1"
+        }
+      }
+    },
+    "/apis/resource.k8s.io/v1/resourceclaims": {
+      "get": {
+        "description": "list or watch objects of kind ResourceClaim",
+        "operationId": "listResourceV1ResourceClaimForAllNamespaces",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimList"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "list",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "in": "query",
+          "name": "continue",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "in": "query",
+          "name": "fieldSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "in": "query",
+          "name": "labelSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "in": "query",
+          "name": "limit",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersion",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+          "in": "query",
+          "name": "sendInitialEvents",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "in": "query",
+          "name": "timeoutSeconds",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "in": "query",
+          "name": "watch",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/resource.k8s.io/v1/resourceclaimtemplates": {
+      "get": {
+        "description": "list or watch objects of kind ResourceClaimTemplate",
+        "operationId": "listResourceV1ResourceClaimTemplateForAllNamespaces",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceClaimTemplateList"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "list",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimTemplate",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "in": "query",
+          "name": "continue",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "in": "query",
+          "name": "fieldSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "in": "query",
+          "name": "labelSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "in": "query",
+          "name": "limit",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersion",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+          "in": "query",
+          "name": "sendInitialEvents",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "in": "query",
+          "name": "timeoutSeconds",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "in": "query",
+          "name": "watch",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/resource.k8s.io/v1/resourceslices": {
+      "delete": {
+        "description": "delete collection of ResourceSlice",
+        "operationId": "deleteResourceV1CollectionResourceSlice",
+        "parameters": [
+          {
+            "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+            "in": "query",
+            "name": "continue",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+            "in": "query",
+            "name": "fieldSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "in": "query",
+            "name": "gracePeriodSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+            "in": "query",
+            "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+            "in": "query",
+            "name": "labelSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "in": "query",
+            "name": "orphanDependents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "in": "query",
+            "name": "propagationPolicy",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersion",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersionMatch",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+            "in": "query",
+            "name": "sendInitialEvents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+            "in": "query",
+            "name": "timeoutSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "deletecollection",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceSlice",
+          "version": "v1"
+        }
+      },
+      "get": {
+        "description": "list or watch objects of kind ResourceSlice",
+        "operationId": "listResourceV1ResourceSlice",
+        "parameters": [
+          {
+            "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+            "in": "query",
+            "name": "allowWatchBookmarks",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+            "in": "query",
+            "name": "continue",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+            "in": "query",
+            "name": "fieldSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+            "in": "query",
+            "name": "labelSelector",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersion",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "in": "query",
+            "name": "resourceVersionMatch",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+            "in": "query",
+            "name": "sendInitialEvents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+            "in": "query",
+            "name": "timeoutSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+            "in": "query",
+            "name": "watch",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSliceList"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSliceList"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSliceList"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSliceList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSliceList"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSliceList"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSliceList"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "list",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceSlice",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ],
+      "post": {
+        "description": "create a ResourceSlice",
+        "operationId": "createResourceV1ResourceSlice",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "202": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "post",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceSlice",
+          "version": "v1"
+        }
+      }
+    },
+    "/apis/resource.k8s.io/v1/resourceslices/{name}": {
+      "delete": {
+        "description": "delete a ResourceSlice",
+        "operationId": "deleteResourceV1ResourceSlice",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "in": "query",
+            "name": "gracePeriodSeconds",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+            "in": "query",
+            "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "in": "query",
+            "name": "orphanDependents",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "in": "query",
+            "name": "propagationPolicy",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "202": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "delete",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceSlice",
+          "version": "v1"
+        }
+      },
+      "get": {
+        "description": "read the specified ResourceSlice",
+        "operationId": "readResourceV1ResourceSlice",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceSlice",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "name of the ResourceSlice",
+          "in": "path",
+          "name": "name",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ],
+      "patch": {
+        "description": "partially update the specified ResourceSlice",
+        "operationId": "patchResourceV1ResourceSlice",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/apply-patch+cbor": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/apply-patch+yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/strategic-merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "patch",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceSlice",
+          "version": "v1"
+        }
+      },
+      "put": {
+        "description": "replace the specified ResourceSlice",
+        "operationId": "replaceResourceV1ResourceSlice",
+        "parameters": [
+          {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "in": "query",
+            "name": "dryRun",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "in": "query",
+            "name": "fieldManager",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "in": "query",
+            "name": "fieldValidation",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.api.resource.v1.ResourceSlice"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "put",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceSlice",
+          "version": "v1"
+        }
+      }
+    },
+    "/apis/resource.k8s.io/v1/watch/deviceclasses": {
+      "get": {
+        "description": "watch individual changes to a list of DeviceClass. deprecated: use the 'watch' parameter with a list operation instead.",
+        "operationId": "watchResourceV1DeviceClassList",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "watchlist",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "DeviceClass",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "in": "query",
+          "name": "continue",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "in": "query",
+          "name": "fieldSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "in": "query",
+          "name": "labelSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "in": "query",
+          "name": "limit",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersion",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+          "in": "query",
+          "name": "sendInitialEvents",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "in": "query",
+          "name": "timeoutSeconds",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "in": "query",
+          "name": "watch",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/resource.k8s.io/v1/watch/deviceclasses/{name}": {
+      "get": {
+        "description": "watch changes to an object of kind DeviceClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+        "operationId": "watchResourceV1DeviceClass",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "watch",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "DeviceClass",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "in": "query",
+          "name": "continue",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "in": "query",
+          "name": "fieldSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "in": "query",
+          "name": "labelSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "in": "query",
+          "name": "limit",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "name of the DeviceClass",
+          "in": "path",
+          "name": "name",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersion",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+          "in": "query",
+          "name": "sendInitialEvents",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "in": "query",
+          "name": "timeoutSeconds",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "in": "query",
+          "name": "watch",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/resource.k8s.io/v1/watch/namespaces/{namespace}/resourceclaims": {
+      "get": {
+        "description": "watch individual changes to a list of ResourceClaim. deprecated: use the 'watch' parameter with a list operation instead.",
+        "operationId": "watchResourceV1NamespacedResourceClaimList",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "watchlist",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "in": "query",
+          "name": "continue",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "in": "query",
+          "name": "fieldSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "in": "query",
+          "name": "labelSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "in": "query",
+          "name": "limit",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "object name and auth scope, such as for teams and projects",
+          "in": "path",
+          "name": "namespace",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersion",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+          "in": "query",
+          "name": "sendInitialEvents",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "in": "query",
+          "name": "timeoutSeconds",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "in": "query",
+          "name": "watch",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/resource.k8s.io/v1/watch/namespaces/{namespace}/resourceclaims/{name}": {
+      "get": {
+        "description": "watch changes to an object of kind ResourceClaim. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+        "operationId": "watchResourceV1NamespacedResourceClaim",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "watch",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "in": "query",
+          "name": "continue",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "in": "query",
+          "name": "fieldSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "in": "query",
+          "name": "labelSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "in": "query",
+          "name": "limit",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "name of the ResourceClaim",
+          "in": "path",
+          "name": "name",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "object name and auth scope, such as for teams and projects",
+          "in": "path",
+          "name": "namespace",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersion",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+          "in": "query",
+          "name": "sendInitialEvents",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "in": "query",
+          "name": "timeoutSeconds",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "in": "query",
+          "name": "watch",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/resource.k8s.io/v1/watch/namespaces/{namespace}/resourceclaimtemplates": {
+      "get": {
+        "description": "watch individual changes to a list of ResourceClaimTemplate. deprecated: use the 'watch' parameter with a list operation instead.",
+        "operationId": "watchResourceV1NamespacedResourceClaimTemplateList",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "watchlist",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimTemplate",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "in": "query",
+          "name": "continue",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "in": "query",
+          "name": "fieldSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "in": "query",
+          "name": "labelSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "in": "query",
+          "name": "limit",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "object name and auth scope, such as for teams and projects",
+          "in": "path",
+          "name": "namespace",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersion",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+          "in": "query",
+          "name": "sendInitialEvents",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "in": "query",
+          "name": "timeoutSeconds",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "in": "query",
+          "name": "watch",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/resource.k8s.io/v1/watch/namespaces/{namespace}/resourceclaimtemplates/{name}": {
+      "get": {
+        "description": "watch changes to an object of kind ResourceClaimTemplate. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+        "operationId": "watchResourceV1NamespacedResourceClaimTemplate",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "watch",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimTemplate",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "in": "query",
+          "name": "continue",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "in": "query",
+          "name": "fieldSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "in": "query",
+          "name": "labelSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "in": "query",
+          "name": "limit",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "name of the ResourceClaimTemplate",
+          "in": "path",
+          "name": "name",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "object name and auth scope, such as for teams and projects",
+          "in": "path",
+          "name": "namespace",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersion",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+          "in": "query",
+          "name": "sendInitialEvents",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "in": "query",
+          "name": "timeoutSeconds",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "in": "query",
+          "name": "watch",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/resource.k8s.io/v1/watch/resourceclaims": {
+      "get": {
+        "description": "watch individual changes to a list of ResourceClaim. deprecated: use the 'watch' parameter with a list operation instead.",
+        "operationId": "watchResourceV1ResourceClaimListForAllNamespaces",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "watchlist",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "in": "query",
+          "name": "continue",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "in": "query",
+          "name": "fieldSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "in": "query",
+          "name": "labelSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "in": "query",
+          "name": "limit",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersion",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+          "in": "query",
+          "name": "sendInitialEvents",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "in": "query",
+          "name": "timeoutSeconds",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "in": "query",
+          "name": "watch",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/resource.k8s.io/v1/watch/resourceclaimtemplates": {
+      "get": {
+        "description": "watch individual changes to a list of ResourceClaimTemplate. deprecated: use the 'watch' parameter with a list operation instead.",
+        "operationId": "watchResourceV1ResourceClaimTemplateListForAllNamespaces",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "watchlist",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimTemplate",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "in": "query",
+          "name": "continue",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "in": "query",
+          "name": "fieldSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "in": "query",
+          "name": "labelSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "in": "query",
+          "name": "limit",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersion",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+          "in": "query",
+          "name": "sendInitialEvents",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "in": "query",
+          "name": "timeoutSeconds",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "in": "query",
+          "name": "watch",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/resource.k8s.io/v1/watch/resourceslices": {
+      "get": {
+        "description": "watch individual changes to a list of ResourceSlice. deprecated: use the 'watch' parameter with a list operation instead.",
+        "operationId": "watchResourceV1ResourceSliceList",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "watchlist",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceSlice",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "in": "query",
+          "name": "continue",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "in": "query",
+          "name": "fieldSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "in": "query",
+          "name": "labelSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "in": "query",
+          "name": "limit",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersion",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+          "in": "query",
+          "name": "sendInitialEvents",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "in": "query",
+          "name": "timeoutSeconds",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "in": "query",
+          "name": "watch",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/resource.k8s.io/v1/watch/resourceslices/{name}": {
+      "get": {
+        "description": "watch changes to an object of kind ResourceSlice. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+        "operationId": "watchResourceV1ResourceSlice",
+        "responses": {
+          "200": {
+            "content": {
+              "application/cbor": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/cbor-seq": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/vnd.kubernetes.protobuf;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "tags": [
+          "resource_v1"
+        ],
+        "x-kubernetes-action": "watch",
+        "x-kubernetes-group-version-kind": {
+          "group": "resource.k8s.io",
+          "kind": "ResourceSlice",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+          "in": "query",
+          "name": "allowWatchBookmarks",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+          "in": "query",
+          "name": "continue",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+          "in": "query",
+          "name": "fieldSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+          "in": "query",
+          "name": "labelSelector",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+          "in": "query",
+          "name": "limit",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "name of the ResourceSlice",
+          "in": "path",
+          "name": "name",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "in": "query",
+          "name": "pretty",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersion",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+          "in": "query",
+          "name": "resourceVersionMatch",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+          "in": "query",
+          "name": "sendInitialEvents",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+          "in": "query",
+          "name": "timeoutSeconds",
+          "schema": {
+            "type": "integer",
+            "uniqueItems": true
+          }
+        },
+        {
+          "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+          "in": "query",
+          "name": "watch",
+          "schema": {
+            "type": "boolean",
+            "uniqueItems": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/schemas/generator/testdata/cilium_clusterwide_network_policy.yaml
+++ b/internal/schemas/generator/testdata/cilium_clusterwide_network_policy.yaml
@@ -1,0 +1,7054 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: ciliumclusterwidenetworkpolicies.cilium.io
+spec:
+  group: cilium.io
+  names:
+    categories:
+    - cilium
+    - ciliumpolicy
+    kind: CiliumClusterwideNetworkPolicy
+    listKind: CiliumClusterwideNetworkPolicyList
+    plural: ciliumclusterwidenetworkpolicies
+    shortNames:
+    - ccnp
+    singular: ciliumclusterwidenetworkpolicy
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+      name: Valid
+      type: string
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          CiliumClusterwideNetworkPolicy is a Kubernetes third-party resource with an
+          modified version of CiliumNetworkPolicy which is cluster scoped rather than
+          namespace scoped.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            anyOf:
+            - properties:
+                ingress: {}
+              required:
+              - ingress
+            - properties:
+                ingressDeny: {}
+              required:
+              - ingressDeny
+            - properties:
+                egress: {}
+              required:
+              - egress
+            - properties:
+                egressDeny: {}
+              required:
+              - egressDeny
+            description: Spec is the desired Cilium specific rule specification.
+            oneOf:
+            - properties:
+                endpointSelector: {}
+              required:
+              - endpointSelector
+            - properties:
+                nodeSelector: {}
+              required:
+              - nodeSelector
+            properties:
+              description:
+                description: |-
+                  Description is a free form string, it can be used by the creator of
+                  the rule to store human readable explanation of the purpose of this
+                  rule. Rules cannot be identified by comment.
+                type: string
+              egress:
+                description: |-
+                  Egress is a list of EgressRule which are enforced at egress.
+                  If omitted or empty, this rule does not apply at egress.
+                items:
+                  description: |-
+                    EgressRule contains all rule types which can be applied at egress, i.e.
+                    network traffic that originates inside the endpoint and exits the endpoint
+                    selected by the endpointSelector.
+
+                      - All members of this structure are optional. If omitted or empty, the
+                        member will have no effect on the rule.
+
+                      - If multiple members of the structure are specified, then all members
+                        must match in order for the rule to take effect. The exception to this
+                        rule is the ToRequires member; the effects of any Requires field in any
+                        rule will apply to all other rules as well.
+
+                      - ToEndpoints, ToCIDR, ToCIDRSet, ToEntities, ToServices and ToGroups are
+                        mutually exclusive. Only one of these members may be present within an
+                        individual rule.
+                  properties:
+                    authentication:
+                      description: Authentication is the required authentication type
+                        for the allowed traffic, if any.
+                      properties:
+                        mode:
+                          description: Mode is the required authentication mode for
+                            the allowed traffic, if any.
+                          enum:
+                          - disabled
+                          - required
+                          - test-always-fail
+                          type: string
+                      required:
+                      - mode
+                      type: object
+                    icmps:
+                      description: |-
+                        ICMPs is a list of ICMP rule identified by type number
+                        which the endpoint subject to the rule is allowed to connect to.
+
+                        Example:
+                        Any endpoint with the label "app=httpd" is allowed to initiate
+                        type 8 ICMP connections.
+                      items:
+                        description: ICMPRule is a list of ICMP fields.
+                        properties:
+                          fields:
+                            description: Fields is a list of ICMP fields.
+                            items:
+                              description: ICMPField is a ICMP field.
+                              properties:
+                                family:
+                                  default: IPv4
+                                  description: |-
+                                    Family is a IP address version.
+                                    Currently, we support `IPv4` and `IPv6`.
+                                    `IPv4` is set as default.
+                                  enum:
+                                  - IPv4
+                                  - IPv6
+                                  type: string
+                                type:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: "Type is a ICMP-type.\nIt should be
+                                    an 8bit code (0-255), or it's CamelCase name (for
+                                    example, \"EchoReply\").\nAllowed ICMP types are:\n
+                                    \   Ipv4: EchoReply | DestinationUnreachable |
+                                    Redirect | Echo | EchoRequest |\n\t\t     RouterAdvertisement
+                                    | RouterSelection | TimeExceeded | ParameterProblem
+                                    |\n\t\t\t Timestamp | TimestampReply | Photuris
+                                    | ExtendedEcho Request | ExtendedEcho Reply\n
+                                    \   Ipv6: DestinationUnreachable | PacketTooBig
+                                    | TimeExceeded | ParameterProblem |\n\t\t\t EchoRequest
+                                    | EchoReply | MulticastListenerQuery| MulticastListenerReport
+                                    |\n\t\t\t MulticastListenerDone | RouterSolicitation
+                                    | RouterAdvertisement | NeighborSolicitation |\n\t\t\t
+                                    NeighborAdvertisement | RedirectMessage | RouterRenumbering
+                                    | ICMPNodeInformationQuery |\n\t\t\t ICMPNodeInformationResponse
+                                    | InverseNeighborDiscoverySolicitation | InverseNeighborDiscoveryAdvertisement
+                                    |\n\t\t\t HomeAgentAddressDiscoveryRequest | HomeAgentAddressDiscoveryReply
+                                    | MobilePrefixSolicitation |\n\t\t\t MobilePrefixAdvertisement
+                                    | DuplicateAddressRequestCodeSuffix | DuplicateAddressConfirmationCodeSuffix
+                                    |\n\t\t\t ExtendedEchoRequest | ExtendedEchoReply"
+                                  pattern: ^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]|EchoReply|DestinationUnreachable|Redirect|Echo|RouterAdvertisement|RouterSelection|TimeExceeded|ParameterProblem|Timestamp|TimestampReply|Photuris|ExtendedEchoRequest|ExtendedEcho
+                                    Reply|PacketTooBig|ParameterProblem|EchoRequest|MulticastListenerQuery|MulticastListenerReport|MulticastListenerDone|RouterSolicitation|RouterAdvertisement|NeighborSolicitation|NeighborAdvertisement|RedirectMessage|RouterRenumbering|ICMPNodeInformationQuery|ICMPNodeInformationResponse|InverseNeighborDiscoverySolicitation|InverseNeighborDiscoveryAdvertisement|HomeAgentAddressDiscoveryRequest|HomeAgentAddressDiscoveryReply|MobilePrefixSolicitation|MobilePrefixAdvertisement|DuplicateAddressRequestCodeSuffix|DuplicateAddressConfirmationCodeSuffix)$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                            maxItems: 40
+                            type: array
+                        type: object
+                      type: array
+                    toCIDR:
+                      description: |-
+                        ToCIDR is a list of IP blocks which the endpoint subject to the rule
+                        is allowed to initiate connections. Only connections destined for
+                        outside of the cluster and not targeting the host will be subject
+                        to CIDR rules.  This will match on the destination IP address of
+                        outgoing connections. Adding a prefix into ToCIDR or into ToCIDRSet
+                        with no ExcludeCIDRs is equivalent. Overlaps are allowed between
+                        ToCIDR and ToCIDRSet.
+
+                        Example:
+                        Any endpoint with the label "app=database-proxy" is allowed to
+                        initiate connections to 10.2.3.0/24
+                      items:
+                        description: |-
+                          CIDR specifies a block of IP addresses.
+                          Example: 192.0.2.1/32
+                        format: cidr
+                        type: string
+                      type: array
+                    toCIDRSet:
+                      description: |-
+                        ToCIDRSet is a list of IP blocks which the endpoint subject to the rule
+                        is allowed to initiate connections to in addition to connections
+                        which are allowed via ToEndpoints, along with a list of subnets contained
+                        within their corresponding IP block to which traffic should not be
+                        allowed. This will match on the destination IP address of outgoing
+                        connections. Adding a prefix into ToCIDR or into ToCIDRSet with no
+                        ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and
+                        ToCIDRSet.
+
+                        Example:
+                        Any endpoint with the label "app=database-proxy" is allowed to
+                        initiate connections to 10.2.3.0/24 except from IPs in subnet 10.2.3.0/28.
+                      items:
+                        description: |-
+                          CIDRRule is a rule that specifies a CIDR prefix to/from which outside
+                          communication  is allowed, along with an optional list of subnets within that
+                          CIDR prefix to/from which outside communication is not allowed.
+                        oneOf:
+                        - properties:
+                            cidr: {}
+                          required:
+                          - cidr
+                        - properties:
+                            cidrGroupRef: {}
+                          required:
+                          - cidrGroupRef
+                        - properties:
+                            cidrGroupSelector: {}
+                          required:
+                          - cidrGroupSelector
+                        properties:
+                          cidr:
+                            description: CIDR is a CIDR prefix / IP Block.
+                            format: cidr
+                            type: string
+                          cidrGroupRef:
+                            description: |-
+                              CIDRGroupRef is a reference to a CiliumCIDRGroup object.
+                              A CiliumCIDRGroup contains a list of CIDRs that the endpoint, subject to
+                              the rule, can (Ingress/Egress) or cannot (IngressDeny/EgressDeny) receive
+                              connections from.
+                            maxLength: 253
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          cidrGroupSelector:
+                            description: |-
+                              CIDRGroupSelector selects CiliumCIDRGroups by their labels,
+                              rather than by name.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  description: MatchLabelsValue represents the value
+                                    from the MatchLabels {key,value} pair.
+                                  maxLength: 63
+                                  pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          except:
+                            description: |-
+                              ExceptCIDRs is a list of IP blocks which the endpoint subject to the rule
+                              is not allowed to initiate connections to. These CIDR prefixes should be
+                              contained within Cidr, using ExceptCIDRs together with CIDRGroupRef is not
+                              supported yet.
+                              These exceptions are only applied to the Cidr in this CIDRRule, and do not
+                              apply to any other CIDR prefixes in any other CIDRRules.
+                            items:
+                              description: |-
+                                CIDR specifies a block of IP addresses.
+                                Example: 192.0.2.1/32
+                              format: cidr
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    toEndpoints:
+                      description: |-
+                        ToEndpoints is a list of endpoints identified by an EndpointSelector to
+                        which the endpoints subject to the rule are allowed to communicate.
+
+                        Example:
+                        Any endpoint with the label "role=frontend" can communicate with any
+                        endpoint carrying the label "role=backend".
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    toEntities:
+                      description: |-
+                        ToEntities is a list of special entities to which the endpoint subject
+                        to the rule is allowed to initiate connections. Supported entities are
+                        `world`, `cluster`,`host`,`remote-node`,`kube-apiserver`, `init`,
+                        `health`,`unmanaged` and `all`.
+                      items:
+                        description: |-
+                          Entity specifies the class of receiver/sender endpoints that do not have
+                          individual identities.  Entities are used to describe "outside of cluster",
+                          "host", etc.
+                        enum:
+                        - all
+                        - world
+                        - cluster
+                        - host
+                        - init
+                        - ingress
+                        - unmanaged
+                        - remote-node
+                        - health
+                        - none
+                        - kube-apiserver
+                        type: string
+                      type: array
+                    toFQDNs:
+                      description: |-
+                        ToFQDN allows whitelisting DNS names in place of IPs. The IPs that result
+                        from DNS resolution of `ToFQDN.MatchName`s are added to the same
+                        EgressRule object as ToCIDRSet entries, and behave accordingly. Any L4 and
+                        L7 rules within this EgressRule will also apply to these IPs.
+                        The DNS -> IP mapping is re-resolved periodically from within the
+                        cilium-agent, and the IPs in the DNS response are effected in the policy
+                        for selected pods as-is (i.e. the list of IPs is not modified in any way).
+                        Note: An explicit rule to allow for DNS traffic is needed for the pods, as
+                        ToFQDN counts as an egress rule and will enforce egress policy when
+                        PolicyEnforcment=default.
+                        Note: If the resolved IPs are IPs within the kubernetes cluster, the
+                        ToFQDN rule will not apply to that IP.
+                        Note: ToFQDN cannot occur in the same policy as other To* rules.
+                      items:
+                        oneOf:
+                        - properties:
+                            matchName: {}
+                          required:
+                          - matchName
+                        - properties:
+                            matchPattern: {}
+                          required:
+                          - matchPattern
+                        properties:
+                          matchName:
+                            description: |-
+                              MatchName matches literal DNS names. A trailing "." is automatically added
+                              when missing.
+                            maxLength: 255
+                            pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                            type: string
+                          matchPattern:
+                            description: |-
+                              MatchPattern allows using wildcards to match DNS names. All wildcards are
+                              case insensitive. The wildcards are:
+                              - "*" matches 0 or more DNS valid characters, and may occur anywhere in
+                              the pattern. As a special case a "*" as the leftmost character, without a
+                              following "." matches all subdomains as well as the name to the right.
+                              A trailing "." is automatically added when missing.
+
+                              Examples:
+                              `*.cilium.io` matches subomains of cilium at that level
+                                www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
+                              `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                except those containing "." separator, subcilium.io and sub-cilium.io match,
+                                www.cilium.io and blog.cilium.io does not
+                              sub*.cilium.io matches subdomains of cilium where the subdomain component
+                              begins with "sub"
+                                sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                blog.cilium.io, cilium.io and google.com do not
+                            maxLength: 255
+                            pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                            type: string
+                        type: object
+                      type: array
+                    toGroups:
+                      description: |-
+                        ToGroups is a directive that allows the integration with multiple outside
+                        providers. Currently, only AWS is supported, and the rule can select by
+                        multiple sub directives:
+
+                        Example:
+                        toGroups:
+                        - aws:
+                            securityGroupsIds:
+                            - 'sg-XXXXXXXXXXXXX'
+                      items:
+                        description: |-
+                          Groups structure to store all kinds of new integrations that needs a new
+                          derivative policy.
+                        properties:
+                          aws:
+                            description: AWSGroup is an structure that can be used
+                              to whitelisting information from AWS integration
+                            properties:
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              region:
+                                type: string
+                              securityGroupsIds:
+                                items:
+                                  type: string
+                                type: array
+                              securityGroupsNames:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                    toNodes:
+                      description: |-
+                        ToNodes is a list of nodes identified by an
+                        EndpointSelector to which endpoints subject to the rule is allowed to communicate.
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    toPorts:
+                      description: |-
+                        ToPorts is a list of destination ports identified by port number and
+                        protocol which the endpoint subject to the rule is allowed to
+                        connect to.
+
+                        Example:
+                        Any endpoint with the label "role=frontend" is allowed to initiate
+                        connections to destination port 8080/tcp
+                      items:
+                        description: |-
+                          PortRule is a list of ports/protocol combinations with optional Layer 7
+                          rules which must be met.
+                        properties:
+                          listener:
+                            description: |-
+                              listener specifies the name of a custom Envoy listener to which this traffic should be
+                              redirected to.
+                            properties:
+                              envoyConfig:
+                                description: |-
+                                  EnvoyConfig is a reference to the CEC or CCEC resource in which
+                                  the listener is defined.
+                                properties:
+                                  kind:
+                                    description: |-
+                                      Kind is the resource type being referred to. Defaults to CiliumEnvoyConfig or
+                                      CiliumClusterwideEnvoyConfig for CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy,
+                                      respectively. The only case this is currently explicitly needed is when referring to a
+                                      CiliumClusterwideEnvoyConfig from CiliumNetworkPolicy, as using a namespaced listener
+                                      from a cluster scoped policy is not allowed.
+                                    enum:
+                                    - CiliumEnvoyConfig
+                                    - CiliumClusterwideEnvoyConfig
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is the resource name of the CiliumEnvoyConfig or CiliumClusterwideEnvoyConfig where
+                                      the listener is defined in.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              name:
+                                description: Name is the name of the listener.
+                                minLength: 1
+                                type: string
+                              priority:
+                                description: |-
+                                  Priority for this Listener that is used when multiple rules would apply different
+                                  listeners to a policy map entry. Behavior of this is implementation dependent.
+                                maximum: 100
+                                minimum: 1
+                                type: integer
+                            required:
+                            - envoyConfig
+                            - name
+                            type: object
+                          originatingTLS:
+                            description: |-
+                              OriginatingTLS is the TLS context for the connections originated by
+                              the L7 proxy.  For egress policy this specifies the client-side TLS
+                              parameters for the upstream connection originating from the L7 proxy
+                              to the remote destination. For ingress policy this specifies the
+                              client-side TLS parameters for the connection from the L7 proxy to
+                              the local endpoint.
+                            properties:
+                              certificate:
+                                description: |-
+                                  Certificate is the file name or k8s secret item name for the certificate
+                                  chain. If omitted, 'tls.crt' is assumed, if it exists. If given, the
+                                  item must exist.
+                                type: string
+                              privateKey:
+                                description: |-
+                                  PrivateKey is the file name or k8s secret item name for the private key
+                                  matching the certificate chain. If omitted, 'tls.key' is assumed, if it
+                                  exists. If given, the item must exist.
+                                type: string
+                              secret:
+                                description: |-
+                                  Secret is the secret that contains the certificates and private key for
+                                  the TLS context.
+                                  By default, Cilium will search in this secret for the following items:
+                                   - 'ca.crt'  - Which represents the trusted CA to verify remote source.
+                                   - 'tls.crt' - Which represents the public key certificate.
+                                   - 'tls.key' - Which represents the private key matching the public key
+                                                 certificate.
+                                properties:
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace in which the secret exists. Context of use
+                                      determines the default value if left out (e.g., "default").
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              trustedCA:
+                                description: |-
+                                  TrustedCA is the file name or k8s secret item name for the trusted CA.
+                                  If omitted, 'ca.crt' is assumed, if it exists. If given, the item must
+                                  exist.
+                                type: string
+                            required:
+                            - secret
+                            type: object
+                          ports:
+                            description: Ports is a list of L4 port/protocol
+                            items:
+                              description: PortProtocol specifies an L4 port with
+                                an optional transport protocol
+                              properties:
+                                endPort:
+                                  description: EndPort can only be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
+                                port:
+                                  description: |-
+                                    Port can be an L4 port number, or a name in the form of "http"
+                                    or "http-8080".
+                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                  type: string
+                                protocol:
+                                  description: |-
+                                    Protocol is the L4 protocol. If omitted or empty, any protocol
+                                    matches. Accepted values: "TCP", "UDP", "SCTP", "ANY"
+
+                                    Matching on ICMP is not supported.
+
+                                    Named port specified for a container may narrow this down, but may not
+                                    contradict this.
+                                  enum:
+                                  - TCP
+                                  - UDP
+                                  - SCTP
+                                  - ANY
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            maxItems: 40
+                            type: array
+                          rules:
+                            description: |-
+                              Rules is a list of additional port level rules which must be met in
+                              order for the PortRule to allow the traffic. If omitted or empty,
+                              no layer 7 rules are enforced.
+                            oneOf:
+                            - properties:
+                                http: {}
+                              required:
+                              - http
+                            - properties:
+                                kafka: {}
+                              required:
+                              - kafka
+                            - properties:
+                                dns: {}
+                              required:
+                              - dns
+                            - properties:
+                                l7proto: {}
+                              required:
+                              - l7proto
+                            properties:
+                              dns:
+                                description: DNS-specific rules.
+                                items:
+                                  description: PortRuleDNS is a list of allowed DNS
+                                    lookups.
+                                  oneOf:
+                                  - properties:
+                                      matchName: {}
+                                    required:
+                                    - matchName
+                                  - properties:
+                                      matchPattern: {}
+                                    required:
+                                    - matchPattern
+                                  properties:
+                                    matchName:
+                                      description: |-
+                                        MatchName matches literal DNS names. A trailing "." is automatically added
+                                        when missing.
+                                      maxLength: 255
+                                      pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                                      type: string
+                                    matchPattern:
+                                      description: |-
+                                        MatchPattern allows using wildcards to match DNS names. All wildcards are
+                                        case insensitive. The wildcards are:
+                                        - "*" matches 0 or more DNS valid characters, and may occur anywhere in
+                                        the pattern. As a special case a "*" as the leftmost character, without a
+                                        following "." matches all subdomains as well as the name to the right.
+                                        A trailing "." is automatically added when missing.
+
+                                        Examples:
+                                        `*.cilium.io` matches subomains of cilium at that level
+                                          www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
+                                        `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                          except those containing "." separator, subcilium.io and sub-cilium.io match,
+                                          www.cilium.io and blog.cilium.io does not
+                                        sub*.cilium.io matches subdomains of cilium where the subdomain component
+                                        begins with "sub"
+                                          sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                          blog.cilium.io, cilium.io and google.com do not
+                                      maxLength: 255
+                                      pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                                      type: string
+                                  type: object
+                                type: array
+                              http:
+                                description: HTTP specific rules.
+                                items:
+                                  description: |-
+                                    PortRuleHTTP is a list of HTTP protocol constraints. All fields are
+                                    optional, if all fields are empty or missing, the rule does not have any
+                                    effect.
+
+                                    All fields of this type are extended POSIX regex as defined by IEEE Std
+                                    1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax)
+                                    matched against the path of an incoming request. Currently it can contain
+                                    characters disallowed from the conventional "path" part of a URL as defined
+                                    by RFC 3986.
+                                  properties:
+                                    headerMatches:
+                                      description: |-
+                                        HeaderMatches is a list of HTTP headers which must be
+                                        present and match against the given values. Mismatch field can be used
+                                        to specify what to do when there is no match.
+                                      items:
+                                        description: |-
+                                          HeaderMatch extends the HeaderValue for matching requirement of a
+                                          named header field against an immediate string, a secret value, or
+                                          a regex.  If none of the optional fields is present, then the
+                                          header value is not matched, only presence of the header is enough.
+                                        properties:
+                                          mismatch:
+                                            description: |-
+                                              Mismatch identifies what to do in case there is no match. The default is
+                                              to drop the request. Otherwise the overall rule is still considered as
+                                              matching, but the mismatches are logged in the access log.
+                                            enum:
+                                            - LOG
+                                            - ADD
+                                            - DELETE
+                                            - REPLACE
+                                            type: string
+                                          name:
+                                            description: Name identifies the header.
+                                            minLength: 1
+                                            type: string
+                                          secret:
+                                            description: |-
+                                              Secret refers to a secret that contains the value to be matched against.
+                                              The secret must only contain one entry. If the referred secret does not
+                                              exist, and there is no "Value" specified, the match will fail.
+                                            properties:
+                                              name:
+                                                description: Name is the name of the
+                                                  secret.
+                                                type: string
+                                              namespace:
+                                                description: |-
+                                                  Namespace is the namespace in which the secret exists. Context of use
+                                                  determines the default value if left out (e.g., "default").
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          value:
+                                            description: |-
+                                              Value matches the exact value of the header. Can be specified either
+                                              alone or together with "Secret"; will be used as the header value if the
+                                              secret can not be found in the latter case.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    headers:
+                                      description: |-
+                                        Headers is a list of HTTP headers which must be present in the
+                                        request. If omitted or empty, requests are allowed regardless of
+                                        headers present.
+                                      items:
+                                        type: string
+                                      type: array
+                                    host:
+                                      description: |-
+                                        Host is an extended POSIX regex matched against the host header of a
+                                        request. Examples:
+
+                                        - foo.bar.com will match the host fooXbar.com or foo-bar.com
+                                        - foo\.bar\.com will only match the host foo.bar.com
+
+                                        If omitted or empty, the value of the host header is ignored.
+                                      format: idn-hostname
+                                      type: string
+                                    method:
+                                      description: |-
+                                        Method is an extended POSIX regex matched against the method of a
+                                        request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                                        If omitted or empty, all methods are allowed.
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path is an extended POSIX regex matched against the path of a
+                                        request. Currently it can contain characters disallowed from the
+                                        conventional "path" part of a URL as defined by RFC 3986.
+
+                                        If omitted or empty, all paths are all allowed.
+                                      type: string
+                                  type: object
+                                type: array
+                              kafka:
+                                description: Kafka-specific rules.
+                                items:
+                                  description: |-
+                                    PortRule is a list of Kafka protocol constraints. All fields are
+                                    optional, if all fields are empty or missing, the rule will match all
+                                    Kafka messages.
+                                  properties:
+                                    apiKey:
+                                      description: |-
+                                        APIKey is a case-insensitive string matched against the key of a
+                                        request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al
+                                        Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                                        If omitted or empty, and if Role is not specified, then all keys are allowed.
+                                      type: string
+                                    apiVersion:
+                                      description: |-
+                                        APIVersion is the version matched against the api version of the
+                                        Kafka message. If set, it has to be a string representing a positive
+                                        integer.
+
+                                        If omitted or empty, all versions are allowed.
+                                      type: string
+                                    clientID:
+                                      description: |-
+                                        ClientID is the client identifier as provided in the request.
+
+                                        From Kafka protocol documentation:
+                                        This is a user supplied identifier for the client application. The
+                                        user can use any identifier they like and it will be used when
+                                        logging errors, monitoring aggregates, etc. For example, one might
+                                        want to monitor not just the requests per second overall, but the
+                                        number coming from each client application (each of which could
+                                        reside on multiple servers). This id acts as a logical grouping
+                                        across all requests from a particular client.
+
+                                        If omitted or empty, all client identifiers are allowed.
+                                      type: string
+                                    role:
+                                      description: |-
+                                        Role is a case-insensitive string and describes a group of API keys
+                                        necessary to perform certain higher-level Kafka operations such as "produce"
+                                        or "consume". A Role automatically expands into all APIKeys required
+                                        to perform the specified higher-level operation.
+
+                                        The following values are supported:
+                                         - "produce": Allow producing to the topics specified in the rule
+                                         - "consume": Allow consuming from the topics specified in the rule
+
+                                        This field is incompatible with the APIKey field, i.e APIKey and Role
+                                        cannot both be specified in the same rule.
+
+                                        If omitted or empty, and if APIKey is not specified, then all keys are
+                                        allowed.
+                                      enum:
+                                      - produce
+                                      - consume
+                                      type: string
+                                    topic:
+                                      description: |-
+                                        Topic is the topic name contained in the message. If a Kafka request
+                                        contains multiple topics, then all topics must be allowed or the
+                                        message will be rejected.
+
+                                        This constraint is ignored if the matched request message type
+                                        doesn't contain any topic. Maximum size of Topic can be 249
+                                        characters as per recent Kafka spec and allowed characters are
+                                        a-z, A-Z, 0-9, -, . and _.
+
+                                        Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10
+                                        version the length was changed from 255 to 249. For compatibility
+                                        reasons we are using 255.
+
+                                        If omitted or empty, all topics are allowed.
+                                      maxLength: 255
+                                      type: string
+                                  type: object
+                                type: array
+                              l7:
+                                description: Key-value pair rules.
+                                items:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    PortRuleL7 is a list of key-value pairs interpreted by a L7 protocol as
+                                    protocol constraints. All fields are optional, if all fields are empty or
+                                    missing, the rule does not have any effect.
+                                  type: object
+                                type: array
+                              l7proto:
+                                description: Name of the L7 protocol for which the
+                                  Key-value pair rules apply.
+                                type: string
+                            type: object
+                          serverNames:
+                            description: |-
+                              ServerNames is a list of allowed TLS SNI values. If not empty, then
+                              TLS must be present and one of the provided SNIs must be indicated in the
+                              TLS handshake.
+                            items:
+                              type: string
+                            type: array
+                          terminatingTLS:
+                            description: |-
+                              TerminatingTLS is the TLS context for the connection terminated by
+                              the L7 proxy.  For egress policy this specifies the server-side TLS
+                              parameters to be applied on the connections originated from the local
+                              endpoint and terminated by the L7 proxy. For ingress policy this specifies
+                              the server-side TLS parameters to be applied on the connections
+                              originated from a remote source and terminated by the L7 proxy.
+                            properties:
+                              certificate:
+                                description: |-
+                                  Certificate is the file name or k8s secret item name for the certificate
+                                  chain. If omitted, 'tls.crt' is assumed, if it exists. If given, the
+                                  item must exist.
+                                type: string
+                              privateKey:
+                                description: |-
+                                  PrivateKey is the file name or k8s secret item name for the private key
+                                  matching the certificate chain. If omitted, 'tls.key' is assumed, if it
+                                  exists. If given, the item must exist.
+                                type: string
+                              secret:
+                                description: |-
+                                  Secret is the secret that contains the certificates and private key for
+                                  the TLS context.
+                                  By default, Cilium will search in this secret for the following items:
+                                   - 'ca.crt'  - Which represents the trusted CA to verify remote source.
+                                   - 'tls.crt' - Which represents the public key certificate.
+                                   - 'tls.key' - Which represents the private key matching the public key
+                                                 certificate.
+                                properties:
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace in which the secret exists. Context of use
+                                      determines the default value if left out (e.g., "default").
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              trustedCA:
+                                description: |-
+                                  TrustedCA is the file name or k8s secret item name for the trusted CA.
+                                  If omitted, 'ca.crt' is assumed, if it exists. If given, the item must
+                                  exist.
+                                type: string
+                            required:
+                            - secret
+                            type: object
+                        type: object
+                      type: array
+                    toRequires:
+                      description: |-
+                        ToRequires is a list of additional constraints which must be met
+                        in order for the selected endpoints to be able to connect to other
+                        endpoints. These additional constraints do no by itself grant access
+                        privileges and must always be accompanied with at least one matching
+                        ToEndpoints.
+
+                        Example:
+                        Any Endpoint with the label "team=A" requires any endpoint to which it
+                        communicates to also carry the label "team=A".
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    toServices:
+                      description: |-
+                        ToServices is a list of services to which the endpoint subject
+                        to the rule is allowed to initiate connections.
+                        Currently Cilium only supports toServices for K8s services.
+                      items:
+                        description: |-
+                          Service selects policy targets that are bundled as part of a
+                          logical load-balanced service.
+
+                          Currently only Kubernetes-based Services are supported.
+                        properties:
+                          k8sService:
+                            description: K8sService selects service by name and namespace
+                              pair
+                            properties:
+                              namespace:
+                                type: string
+                              serviceName:
+                                type: string
+                            type: object
+                          k8sServiceSelector:
+                            description: K8sServiceSelector selects services by k8s
+                              labels and namespace
+                            properties:
+                              namespace:
+                                type: string
+                              selector:
+                                description: ServiceSelector is a label selector for
+                                  k8s services
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      description: MatchLabelsValue represents the
+                                        value from the MatchLabels {key,value} pair.
+                                      maxLength: 63
+                                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - selector
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              egressDeny:
+                description: |-
+                  EgressDeny is a list of EgressDenyRule which are enforced at egress.
+                  Any rule inserted here will be denied regardless of the allowed egress
+                  rules in the 'egress' field.
+                  If omitted or empty, this rule does not apply at egress.
+                items:
+                  description: |-
+                    EgressDenyRule contains all rule types which can be applied at egress, i.e.
+                    network traffic that originates inside the endpoint and exits the endpoint
+                    selected by the endpointSelector.
+
+                      - All members of this structure are optional. If omitted or empty, the
+                        member will have no effect on the rule.
+
+                      - If multiple members of the structure are specified, then all members
+                        must match in order for the rule to take effect. The exception to this
+                        rule is the ToRequires member; the effects of any Requires field in any
+                        rule will apply to all other rules as well.
+
+                      - ToEndpoints, ToCIDR, ToCIDRSet, ToEntities, ToServices and ToGroups are
+                        mutually exclusive. Only one of these members may be present within an
+                        individual rule.
+                  properties:
+                    icmps:
+                      description: |-
+                        ICMPs is a list of ICMP rule identified by type number
+                        which the endpoint subject to the rule is not allowed to connect to.
+
+                        Example:
+                        Any endpoint with the label "app=httpd" is not allowed to initiate
+                        type 8 ICMP connections.
+                      items:
+                        description: ICMPRule is a list of ICMP fields.
+                        properties:
+                          fields:
+                            description: Fields is a list of ICMP fields.
+                            items:
+                              description: ICMPField is a ICMP field.
+                              properties:
+                                family:
+                                  default: IPv4
+                                  description: |-
+                                    Family is a IP address version.
+                                    Currently, we support `IPv4` and `IPv6`.
+                                    `IPv4` is set as default.
+                                  enum:
+                                  - IPv4
+                                  - IPv6
+                                  type: string
+                                type:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: "Type is a ICMP-type.\nIt should be
+                                    an 8bit code (0-255), or it's CamelCase name (for
+                                    example, \"EchoReply\").\nAllowed ICMP types are:\n
+                                    \   Ipv4: EchoReply | DestinationUnreachable |
+                                    Redirect | Echo | EchoRequest |\n\t\t     RouterAdvertisement
+                                    | RouterSelection | TimeExceeded | ParameterProblem
+                                    |\n\t\t\t Timestamp | TimestampReply | Photuris
+                                    | ExtendedEcho Request | ExtendedEcho Reply\n
+                                    \   Ipv6: DestinationUnreachable | PacketTooBig
+                                    | TimeExceeded | ParameterProblem |\n\t\t\t EchoRequest
+                                    | EchoReply | MulticastListenerQuery| MulticastListenerReport
+                                    |\n\t\t\t MulticastListenerDone | RouterSolicitation
+                                    | RouterAdvertisement | NeighborSolicitation |\n\t\t\t
+                                    NeighborAdvertisement | RedirectMessage | RouterRenumbering
+                                    | ICMPNodeInformationQuery |\n\t\t\t ICMPNodeInformationResponse
+                                    | InverseNeighborDiscoverySolicitation | InverseNeighborDiscoveryAdvertisement
+                                    |\n\t\t\t HomeAgentAddressDiscoveryRequest | HomeAgentAddressDiscoveryReply
+                                    | MobilePrefixSolicitation |\n\t\t\t MobilePrefixAdvertisement
+                                    | DuplicateAddressRequestCodeSuffix | DuplicateAddressConfirmationCodeSuffix
+                                    |\n\t\t\t ExtendedEchoRequest | ExtendedEchoReply"
+                                  pattern: ^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]|EchoReply|DestinationUnreachable|Redirect|Echo|RouterAdvertisement|RouterSelection|TimeExceeded|ParameterProblem|Timestamp|TimestampReply|Photuris|ExtendedEchoRequest|ExtendedEcho
+                                    Reply|PacketTooBig|ParameterProblem|EchoRequest|MulticastListenerQuery|MulticastListenerReport|MulticastListenerDone|RouterSolicitation|RouterAdvertisement|NeighborSolicitation|NeighborAdvertisement|RedirectMessage|RouterRenumbering|ICMPNodeInformationQuery|ICMPNodeInformationResponse|InverseNeighborDiscoverySolicitation|InverseNeighborDiscoveryAdvertisement|HomeAgentAddressDiscoveryRequest|HomeAgentAddressDiscoveryReply|MobilePrefixSolicitation|MobilePrefixAdvertisement|DuplicateAddressRequestCodeSuffix|DuplicateAddressConfirmationCodeSuffix)$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                            maxItems: 40
+                            type: array
+                        type: object
+                      type: array
+                    toCIDR:
+                      description: |-
+                        ToCIDR is a list of IP blocks which the endpoint subject to the rule
+                        is allowed to initiate connections. Only connections destined for
+                        outside of the cluster and not targeting the host will be subject
+                        to CIDR rules.  This will match on the destination IP address of
+                        outgoing connections. Adding a prefix into ToCIDR or into ToCIDRSet
+                        with no ExcludeCIDRs is equivalent. Overlaps are allowed between
+                        ToCIDR and ToCIDRSet.
+
+                        Example:
+                        Any endpoint with the label "app=database-proxy" is allowed to
+                        initiate connections to 10.2.3.0/24
+                      items:
+                        description: |-
+                          CIDR specifies a block of IP addresses.
+                          Example: 192.0.2.1/32
+                        format: cidr
+                        type: string
+                      type: array
+                    toCIDRSet:
+                      description: |-
+                        ToCIDRSet is a list of IP blocks which the endpoint subject to the rule
+                        is allowed to initiate connections to in addition to connections
+                        which are allowed via ToEndpoints, along with a list of subnets contained
+                        within their corresponding IP block to which traffic should not be
+                        allowed. This will match on the destination IP address of outgoing
+                        connections. Adding a prefix into ToCIDR or into ToCIDRSet with no
+                        ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and
+                        ToCIDRSet.
+
+                        Example:
+                        Any endpoint with the label "app=database-proxy" is allowed to
+                        initiate connections to 10.2.3.0/24 except from IPs in subnet 10.2.3.0/28.
+                      items:
+                        description: |-
+                          CIDRRule is a rule that specifies a CIDR prefix to/from which outside
+                          communication  is allowed, along with an optional list of subnets within that
+                          CIDR prefix to/from which outside communication is not allowed.
+                        oneOf:
+                        - properties:
+                            cidr: {}
+                          required:
+                          - cidr
+                        - properties:
+                            cidrGroupRef: {}
+                          required:
+                          - cidrGroupRef
+                        - properties:
+                            cidrGroupSelector: {}
+                          required:
+                          - cidrGroupSelector
+                        properties:
+                          cidr:
+                            description: CIDR is a CIDR prefix / IP Block.
+                            format: cidr
+                            type: string
+                          cidrGroupRef:
+                            description: |-
+                              CIDRGroupRef is a reference to a CiliumCIDRGroup object.
+                              A CiliumCIDRGroup contains a list of CIDRs that the endpoint, subject to
+                              the rule, can (Ingress/Egress) or cannot (IngressDeny/EgressDeny) receive
+                              connections from.
+                            maxLength: 253
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          cidrGroupSelector:
+                            description: |-
+                              CIDRGroupSelector selects CiliumCIDRGroups by their labels,
+                              rather than by name.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  description: MatchLabelsValue represents the value
+                                    from the MatchLabels {key,value} pair.
+                                  maxLength: 63
+                                  pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          except:
+                            description: |-
+                              ExceptCIDRs is a list of IP blocks which the endpoint subject to the rule
+                              is not allowed to initiate connections to. These CIDR prefixes should be
+                              contained within Cidr, using ExceptCIDRs together with CIDRGroupRef is not
+                              supported yet.
+                              These exceptions are only applied to the Cidr in this CIDRRule, and do not
+                              apply to any other CIDR prefixes in any other CIDRRules.
+                            items:
+                              description: |-
+                                CIDR specifies a block of IP addresses.
+                                Example: 192.0.2.1/32
+                              format: cidr
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    toEndpoints:
+                      description: |-
+                        ToEndpoints is a list of endpoints identified by an EndpointSelector to
+                        which the endpoints subject to the rule are allowed to communicate.
+
+                        Example:
+                        Any endpoint with the label "role=frontend" can communicate with any
+                        endpoint carrying the label "role=backend".
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    toEntities:
+                      description: |-
+                        ToEntities is a list of special entities to which the endpoint subject
+                        to the rule is allowed to initiate connections. Supported entities are
+                        `world`, `cluster`,`host`,`remote-node`,`kube-apiserver`, `init`,
+                        `health`,`unmanaged` and `all`.
+                      items:
+                        description: |-
+                          Entity specifies the class of receiver/sender endpoints that do not have
+                          individual identities.  Entities are used to describe "outside of cluster",
+                          "host", etc.
+                        enum:
+                        - all
+                        - world
+                        - cluster
+                        - host
+                        - init
+                        - ingress
+                        - unmanaged
+                        - remote-node
+                        - health
+                        - none
+                        - kube-apiserver
+                        type: string
+                      type: array
+                    toGroups:
+                      description: |-
+                        ToGroups is a directive that allows the integration with multiple outside
+                        providers. Currently, only AWS is supported, and the rule can select by
+                        multiple sub directives:
+
+                        Example:
+                        toGroups:
+                        - aws:
+                            securityGroupsIds:
+                            - 'sg-XXXXXXXXXXXXX'
+                      items:
+                        description: |-
+                          Groups structure to store all kinds of new integrations that needs a new
+                          derivative policy.
+                        properties:
+                          aws:
+                            description: AWSGroup is an structure that can be used
+                              to whitelisting information from AWS integration
+                            properties:
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              region:
+                                type: string
+                              securityGroupsIds:
+                                items:
+                                  type: string
+                                type: array
+                              securityGroupsNames:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                    toNodes:
+                      description: |-
+                        ToNodes is a list of nodes identified by an
+                        EndpointSelector to which endpoints subject to the rule is allowed to communicate.
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    toPorts:
+                      description: |-
+                        ToPorts is a list of destination ports identified by port number and
+                        protocol which the endpoint subject to the rule is not allowed to connect
+                        to.
+
+                        Example:
+                        Any endpoint with the label "role=frontend" is not allowed to initiate
+                        connections to destination port 8080/tcp
+                      items:
+                        description: |-
+                          PortDenyRule is a list of ports/protocol that should be used for deny
+                          policies. This structure lacks the L7Rules since it's not supported in deny
+                          policies.
+                        properties:
+                          ports:
+                            description: Ports is a list of L4 port/protocol
+                            items:
+                              description: PortProtocol specifies an L4 port with
+                                an optional transport protocol
+                              properties:
+                                endPort:
+                                  description: EndPort can only be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
+                                port:
+                                  description: |-
+                                    Port can be an L4 port number, or a name in the form of "http"
+                                    or "http-8080".
+                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                  type: string
+                                protocol:
+                                  description: |-
+                                    Protocol is the L4 protocol. If omitted or empty, any protocol
+                                    matches. Accepted values: "TCP", "UDP", "SCTP", "ANY"
+
+                                    Matching on ICMP is not supported.
+
+                                    Named port specified for a container may narrow this down, but may not
+                                    contradict this.
+                                  enum:
+                                  - TCP
+                                  - UDP
+                                  - SCTP
+                                  - ANY
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    toRequires:
+                      description: |-
+                        ToRequires is a list of additional constraints which must be met
+                        in order for the selected endpoints to be able to connect to other
+                        endpoints. These additional constraints do no by itself grant access
+                        privileges and must always be accompanied with at least one matching
+                        ToEndpoints.
+
+                        Example:
+                        Any Endpoint with the label "team=A" requires any endpoint to which it
+                        communicates to also carry the label "team=A".
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    toServices:
+                      description: |-
+                        ToServices is a list of services to which the endpoint subject
+                        to the rule is allowed to initiate connections.
+                        Currently Cilium only supports toServices for K8s services.
+                      items:
+                        description: |-
+                          Service selects policy targets that are bundled as part of a
+                          logical load-balanced service.
+
+                          Currently only Kubernetes-based Services are supported.
+                        properties:
+                          k8sService:
+                            description: K8sService selects service by name and namespace
+                              pair
+                            properties:
+                              namespace:
+                                type: string
+                              serviceName:
+                                type: string
+                            type: object
+                          k8sServiceSelector:
+                            description: K8sServiceSelector selects services by k8s
+                              labels and namespace
+                            properties:
+                              namespace:
+                                type: string
+                              selector:
+                                description: ServiceSelector is a label selector for
+                                  k8s services
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      description: MatchLabelsValue represents the
+                                        value from the MatchLabels {key,value} pair.
+                                      maxLength: 63
+                                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - selector
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              enableDefaultDeny:
+                description: |-
+                  EnableDefaultDeny determines whether this policy configures the
+                  subject endpoint(s) to have a default deny mode. If enabled,
+                  this causes all traffic not explicitly allowed by a network policy
+                  to be dropped.
+
+                  If not specified, the default is true for each traffic direction
+                  that has rules, and false otherwise. For example, if a policy
+                  only has Ingress or IngressDeny rules, then the default for
+                  ingress is true and egress is false.
+
+                  If multiple policies apply to an endpoint, that endpoint's default deny
+                  will be enabled if any policy requests it.
+
+                  This is useful for creating broad-based network policies that will not
+                  cause endpoints to enter default-deny mode.
+                properties:
+                  egress:
+                    description: |-
+                      Whether or not the endpoint should have a default-deny rule applied
+                      to egress traffic.
+                    type: boolean
+                  ingress:
+                    description: |-
+                      Whether or not the endpoint should have a default-deny rule applied
+                      to ingress traffic.
+                    type: boolean
+                type: object
+              endpointSelector:
+                description: |-
+                  EndpointSelector selects all endpoints which should be subject to
+                  this rule. EndpointSelector and NodeSelector cannot be both empty and
+                  are mutually exclusive.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              ingress:
+                description: |-
+                  Ingress is a list of IngressRule which are enforced at ingress.
+                  If omitted or empty, this rule does not apply at ingress.
+                items:
+                  description: |-
+                    IngressRule contains all rule types which can be applied at ingress,
+                    i.e. network traffic that originates outside of the endpoint and
+                    is entering the endpoint selected by the endpointSelector.
+
+                      - All members of this structure are optional. If omitted or empty, the
+                        member will have no effect on the rule.
+
+                      - If multiple members are set, all of them need to match in order for
+                        the rule to take effect. The exception to this rule is FromRequires field;
+                        the effects of any Requires field in any rule will apply to all other
+                        rules as well.
+
+                      - FromEndpoints, FromCIDR, FromCIDRSet and FromEntities are mutually
+                        exclusive. Only one of these members may be present within an individual
+                        rule.
+                  properties:
+                    authentication:
+                      description: Authentication is the required authentication type
+                        for the allowed traffic, if any.
+                      properties:
+                        mode:
+                          description: Mode is the required authentication mode for
+                            the allowed traffic, if any.
+                          enum:
+                          - disabled
+                          - required
+                          - test-always-fail
+                          type: string
+                      required:
+                      - mode
+                      type: object
+                    fromCIDR:
+                      description: |-
+                        FromCIDR is a list of IP blocks which the endpoint subject to the
+                        rule is allowed to receive connections from. Only connections which
+                        do *not* originate from the cluster or from the local host are subject
+                        to CIDR rules. In order to allow in-cluster connectivity, use the
+                        FromEndpoints field.  This will match on the source IP address of
+                        incoming connections. Adding  a prefix into FromCIDR or into
+                        FromCIDRSet with no ExcludeCIDRs is  equivalent.  Overlaps are
+                        allowed between FromCIDR and FromCIDRSet.
+
+                        Example:
+                        Any endpoint with the label "app=my-legacy-pet" is allowed to receive
+                        connections from 10.3.9.1
+                      items:
+                        description: |-
+                          CIDR specifies a block of IP addresses.
+                          Example: 192.0.2.1/32
+                        format: cidr
+                        type: string
+                      type: array
+                    fromCIDRSet:
+                      description: |-
+                        FromCIDRSet is a list of IP blocks which the endpoint subject to the
+                        rule is allowed to receive connections from in addition to FromEndpoints,
+                        along with a list of subnets contained within their corresponding IP block
+                        from which traffic should not be allowed.
+                        This will match on the source IP address of incoming connections. Adding
+                        a prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is
+                        equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+
+                        Example:
+                        Any endpoint with the label "app=my-legacy-pet" is allowed to receive
+                        connections from 10.0.0.0/8 except from IPs in subnet 10.96.0.0/12.
+                      items:
+                        description: |-
+                          CIDRRule is a rule that specifies a CIDR prefix to/from which outside
+                          communication  is allowed, along with an optional list of subnets within that
+                          CIDR prefix to/from which outside communication is not allowed.
+                        oneOf:
+                        - properties:
+                            cidr: {}
+                          required:
+                          - cidr
+                        - properties:
+                            cidrGroupRef: {}
+                          required:
+                          - cidrGroupRef
+                        - properties:
+                            cidrGroupSelector: {}
+                          required:
+                          - cidrGroupSelector
+                        properties:
+                          cidr:
+                            description: CIDR is a CIDR prefix / IP Block.
+                            format: cidr
+                            type: string
+                          cidrGroupRef:
+                            description: |-
+                              CIDRGroupRef is a reference to a CiliumCIDRGroup object.
+                              A CiliumCIDRGroup contains a list of CIDRs that the endpoint, subject to
+                              the rule, can (Ingress/Egress) or cannot (IngressDeny/EgressDeny) receive
+                              connections from.
+                            maxLength: 253
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          cidrGroupSelector:
+                            description: |-
+                              CIDRGroupSelector selects CiliumCIDRGroups by their labels,
+                              rather than by name.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  description: MatchLabelsValue represents the value
+                                    from the MatchLabels {key,value} pair.
+                                  maxLength: 63
+                                  pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          except:
+                            description: |-
+                              ExceptCIDRs is a list of IP blocks which the endpoint subject to the rule
+                              is not allowed to initiate connections to. These CIDR prefixes should be
+                              contained within Cidr, using ExceptCIDRs together with CIDRGroupRef is not
+                              supported yet.
+                              These exceptions are only applied to the Cidr in this CIDRRule, and do not
+                              apply to any other CIDR prefixes in any other CIDRRules.
+                            items:
+                              description: |-
+                                CIDR specifies a block of IP addresses.
+                                Example: 192.0.2.1/32
+                              format: cidr
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    fromEndpoints:
+                      description: |-
+                        FromEndpoints is a list of endpoints identified by an
+                        EndpointSelector which are allowed to communicate with the endpoint
+                        subject to the rule.
+
+                        Example:
+                        Any endpoint with the label "role=backend" can be consumed by any
+                        endpoint carrying the label "role=frontend".
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    fromEntities:
+                      description: |-
+                        FromEntities is a list of special entities which the endpoint subject
+                        to the rule is allowed to receive connections from. Supported entities are
+                        `world`, `cluster` and `host`
+                      items:
+                        description: |-
+                          Entity specifies the class of receiver/sender endpoints that do not have
+                          individual identities.  Entities are used to describe "outside of cluster",
+                          "host", etc.
+                        enum:
+                        - all
+                        - world
+                        - cluster
+                        - host
+                        - init
+                        - ingress
+                        - unmanaged
+                        - remote-node
+                        - health
+                        - none
+                        - kube-apiserver
+                        type: string
+                      type: array
+                    fromGroups:
+                      description: |-
+                        FromGroups is a directive that allows the integration with multiple outside
+                        providers. Currently, only AWS is supported, and the rule can select by
+                        multiple sub directives:
+
+                        Example:
+                        FromGroups:
+                        - aws:
+                            securityGroupsIds:
+                            - 'sg-XXXXXXXXXXXXX'
+                      items:
+                        description: |-
+                          Groups structure to store all kinds of new integrations that needs a new
+                          derivative policy.
+                        properties:
+                          aws:
+                            description: AWSGroup is an structure that can be used
+                              to whitelisting information from AWS integration
+                            properties:
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              region:
+                                type: string
+                              securityGroupsIds:
+                                items:
+                                  type: string
+                                type: array
+                              securityGroupsNames:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                    fromNodes:
+                      description: |-
+                        FromNodes is a list of nodes identified by an
+                        EndpointSelector which are allowed to communicate with the endpoint
+                        subject to the rule.
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    fromRequires:
+                      description: |-
+                        FromRequires is a list of additional constraints which must be met
+                        in order for the selected endpoints to be reachable. These
+                        additional constraints do no by itself grant access privileges and
+                        must always be accompanied with at least one matching FromEndpoints.
+
+                        Example:
+                        Any Endpoint with the label "team=A" requires consuming endpoint
+                        to also carry the label "team=A".
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    icmps:
+                      description: |-
+                        ICMPs is a list of ICMP rule identified by type number
+                        which the endpoint subject to the rule is allowed to
+                        receive connections on.
+
+                        Example:
+                        Any endpoint with the label "app=httpd" can only accept incoming
+                        type 8 ICMP connections.
+                      items:
+                        description: ICMPRule is a list of ICMP fields.
+                        properties:
+                          fields:
+                            description: Fields is a list of ICMP fields.
+                            items:
+                              description: ICMPField is a ICMP field.
+                              properties:
+                                family:
+                                  default: IPv4
+                                  description: |-
+                                    Family is a IP address version.
+                                    Currently, we support `IPv4` and `IPv6`.
+                                    `IPv4` is set as default.
+                                  enum:
+                                  - IPv4
+                                  - IPv6
+                                  type: string
+                                type:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: "Type is a ICMP-type.\nIt should be
+                                    an 8bit code (0-255), or it's CamelCase name (for
+                                    example, \"EchoReply\").\nAllowed ICMP types are:\n
+                                    \   Ipv4: EchoReply | DestinationUnreachable |
+                                    Redirect | Echo | EchoRequest |\n\t\t     RouterAdvertisement
+                                    | RouterSelection | TimeExceeded | ParameterProblem
+                                    |\n\t\t\t Timestamp | TimestampReply | Photuris
+                                    | ExtendedEcho Request | ExtendedEcho Reply\n
+                                    \   Ipv6: DestinationUnreachable | PacketTooBig
+                                    | TimeExceeded | ParameterProblem |\n\t\t\t EchoRequest
+                                    | EchoReply | MulticastListenerQuery| MulticastListenerReport
+                                    |\n\t\t\t MulticastListenerDone | RouterSolicitation
+                                    | RouterAdvertisement | NeighborSolicitation |\n\t\t\t
+                                    NeighborAdvertisement | RedirectMessage | RouterRenumbering
+                                    | ICMPNodeInformationQuery |\n\t\t\t ICMPNodeInformationResponse
+                                    | InverseNeighborDiscoverySolicitation | InverseNeighborDiscoveryAdvertisement
+                                    |\n\t\t\t HomeAgentAddressDiscoveryRequest | HomeAgentAddressDiscoveryReply
+                                    | MobilePrefixSolicitation |\n\t\t\t MobilePrefixAdvertisement
+                                    | DuplicateAddressRequestCodeSuffix | DuplicateAddressConfirmationCodeSuffix
+                                    |\n\t\t\t ExtendedEchoRequest | ExtendedEchoReply"
+                                  pattern: ^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]|EchoReply|DestinationUnreachable|Redirect|Echo|RouterAdvertisement|RouterSelection|TimeExceeded|ParameterProblem|Timestamp|TimestampReply|Photuris|ExtendedEchoRequest|ExtendedEcho
+                                    Reply|PacketTooBig|ParameterProblem|EchoRequest|MulticastListenerQuery|MulticastListenerReport|MulticastListenerDone|RouterSolicitation|RouterAdvertisement|NeighborSolicitation|NeighborAdvertisement|RedirectMessage|RouterRenumbering|ICMPNodeInformationQuery|ICMPNodeInformationResponse|InverseNeighborDiscoverySolicitation|InverseNeighborDiscoveryAdvertisement|HomeAgentAddressDiscoveryRequest|HomeAgentAddressDiscoveryReply|MobilePrefixSolicitation|MobilePrefixAdvertisement|DuplicateAddressRequestCodeSuffix|DuplicateAddressConfirmationCodeSuffix)$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                            maxItems: 40
+                            type: array
+                        type: object
+                      type: array
+                    toPorts:
+                      description: |-
+                        ToPorts is a list of destination ports identified by port number and
+                        protocol which the endpoint subject to the rule is allowed to
+                        receive connections on.
+
+                        Example:
+                        Any endpoint with the label "app=httpd" can only accept incoming
+                        connections on port 80/tcp.
+                      items:
+                        description: |-
+                          PortRule is a list of ports/protocol combinations with optional Layer 7
+                          rules which must be met.
+                        properties:
+                          listener:
+                            description: |-
+                              listener specifies the name of a custom Envoy listener to which this traffic should be
+                              redirected to.
+                            properties:
+                              envoyConfig:
+                                description: |-
+                                  EnvoyConfig is a reference to the CEC or CCEC resource in which
+                                  the listener is defined.
+                                properties:
+                                  kind:
+                                    description: |-
+                                      Kind is the resource type being referred to. Defaults to CiliumEnvoyConfig or
+                                      CiliumClusterwideEnvoyConfig for CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy,
+                                      respectively. The only case this is currently explicitly needed is when referring to a
+                                      CiliumClusterwideEnvoyConfig from CiliumNetworkPolicy, as using a namespaced listener
+                                      from a cluster scoped policy is not allowed.
+                                    enum:
+                                    - CiliumEnvoyConfig
+                                    - CiliumClusterwideEnvoyConfig
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is the resource name of the CiliumEnvoyConfig or CiliumClusterwideEnvoyConfig where
+                                      the listener is defined in.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              name:
+                                description: Name is the name of the listener.
+                                minLength: 1
+                                type: string
+                              priority:
+                                description: |-
+                                  Priority for this Listener that is used when multiple rules would apply different
+                                  listeners to a policy map entry. Behavior of this is implementation dependent.
+                                maximum: 100
+                                minimum: 1
+                                type: integer
+                            required:
+                            - envoyConfig
+                            - name
+                            type: object
+                          originatingTLS:
+                            description: |-
+                              OriginatingTLS is the TLS context for the connections originated by
+                              the L7 proxy.  For egress policy this specifies the client-side TLS
+                              parameters for the upstream connection originating from the L7 proxy
+                              to the remote destination. For ingress policy this specifies the
+                              client-side TLS parameters for the connection from the L7 proxy to
+                              the local endpoint.
+                            properties:
+                              certificate:
+                                description: |-
+                                  Certificate is the file name or k8s secret item name for the certificate
+                                  chain. If omitted, 'tls.crt' is assumed, if it exists. If given, the
+                                  item must exist.
+                                type: string
+                              privateKey:
+                                description: |-
+                                  PrivateKey is the file name or k8s secret item name for the private key
+                                  matching the certificate chain. If omitted, 'tls.key' is assumed, if it
+                                  exists. If given, the item must exist.
+                                type: string
+                              secret:
+                                description: |-
+                                  Secret is the secret that contains the certificates and private key for
+                                  the TLS context.
+                                  By default, Cilium will search in this secret for the following items:
+                                   - 'ca.crt'  - Which represents the trusted CA to verify remote source.
+                                   - 'tls.crt' - Which represents the public key certificate.
+                                   - 'tls.key' - Which represents the private key matching the public key
+                                                 certificate.
+                                properties:
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace in which the secret exists. Context of use
+                                      determines the default value if left out (e.g., "default").
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              trustedCA:
+                                description: |-
+                                  TrustedCA is the file name or k8s secret item name for the trusted CA.
+                                  If omitted, 'ca.crt' is assumed, if it exists. If given, the item must
+                                  exist.
+                                type: string
+                            required:
+                            - secret
+                            type: object
+                          ports:
+                            description: Ports is a list of L4 port/protocol
+                            items:
+                              description: PortProtocol specifies an L4 port with
+                                an optional transport protocol
+                              properties:
+                                endPort:
+                                  description: EndPort can only be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
+                                port:
+                                  description: |-
+                                    Port can be an L4 port number, or a name in the form of "http"
+                                    or "http-8080".
+                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                  type: string
+                                protocol:
+                                  description: |-
+                                    Protocol is the L4 protocol. If omitted or empty, any protocol
+                                    matches. Accepted values: "TCP", "UDP", "SCTP", "ANY"
+
+                                    Matching on ICMP is not supported.
+
+                                    Named port specified for a container may narrow this down, but may not
+                                    contradict this.
+                                  enum:
+                                  - TCP
+                                  - UDP
+                                  - SCTP
+                                  - ANY
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            maxItems: 40
+                            type: array
+                          rules:
+                            description: |-
+                              Rules is a list of additional port level rules which must be met in
+                              order for the PortRule to allow the traffic. If omitted or empty,
+                              no layer 7 rules are enforced.
+                            oneOf:
+                            - properties:
+                                http: {}
+                              required:
+                              - http
+                            - properties:
+                                kafka: {}
+                              required:
+                              - kafka
+                            - properties:
+                                dns: {}
+                              required:
+                              - dns
+                            - properties:
+                                l7proto: {}
+                              required:
+                              - l7proto
+                            properties:
+                              dns:
+                                description: DNS-specific rules.
+                                items:
+                                  description: PortRuleDNS is a list of allowed DNS
+                                    lookups.
+                                  oneOf:
+                                  - properties:
+                                      matchName: {}
+                                    required:
+                                    - matchName
+                                  - properties:
+                                      matchPattern: {}
+                                    required:
+                                    - matchPattern
+                                  properties:
+                                    matchName:
+                                      description: |-
+                                        MatchName matches literal DNS names. A trailing "." is automatically added
+                                        when missing.
+                                      maxLength: 255
+                                      pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                                      type: string
+                                    matchPattern:
+                                      description: |-
+                                        MatchPattern allows using wildcards to match DNS names. All wildcards are
+                                        case insensitive. The wildcards are:
+                                        - "*" matches 0 or more DNS valid characters, and may occur anywhere in
+                                        the pattern. As a special case a "*" as the leftmost character, without a
+                                        following "." matches all subdomains as well as the name to the right.
+                                        A trailing "." is automatically added when missing.
+
+                                        Examples:
+                                        `*.cilium.io` matches subomains of cilium at that level
+                                          www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
+                                        `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                          except those containing "." separator, subcilium.io and sub-cilium.io match,
+                                          www.cilium.io and blog.cilium.io does not
+                                        sub*.cilium.io matches subdomains of cilium where the subdomain component
+                                        begins with "sub"
+                                          sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                          blog.cilium.io, cilium.io and google.com do not
+                                      maxLength: 255
+                                      pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                                      type: string
+                                  type: object
+                                type: array
+                              http:
+                                description: HTTP specific rules.
+                                items:
+                                  description: |-
+                                    PortRuleHTTP is a list of HTTP protocol constraints. All fields are
+                                    optional, if all fields are empty or missing, the rule does not have any
+                                    effect.
+
+                                    All fields of this type are extended POSIX regex as defined by IEEE Std
+                                    1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax)
+                                    matched against the path of an incoming request. Currently it can contain
+                                    characters disallowed from the conventional "path" part of a URL as defined
+                                    by RFC 3986.
+                                  properties:
+                                    headerMatches:
+                                      description: |-
+                                        HeaderMatches is a list of HTTP headers which must be
+                                        present and match against the given values. Mismatch field can be used
+                                        to specify what to do when there is no match.
+                                      items:
+                                        description: |-
+                                          HeaderMatch extends the HeaderValue for matching requirement of a
+                                          named header field against an immediate string, a secret value, or
+                                          a regex.  If none of the optional fields is present, then the
+                                          header value is not matched, only presence of the header is enough.
+                                        properties:
+                                          mismatch:
+                                            description: |-
+                                              Mismatch identifies what to do in case there is no match. The default is
+                                              to drop the request. Otherwise the overall rule is still considered as
+                                              matching, but the mismatches are logged in the access log.
+                                            enum:
+                                            - LOG
+                                            - ADD
+                                            - DELETE
+                                            - REPLACE
+                                            type: string
+                                          name:
+                                            description: Name identifies the header.
+                                            minLength: 1
+                                            type: string
+                                          secret:
+                                            description: |-
+                                              Secret refers to a secret that contains the value to be matched against.
+                                              The secret must only contain one entry. If the referred secret does not
+                                              exist, and there is no "Value" specified, the match will fail.
+                                            properties:
+                                              name:
+                                                description: Name is the name of the
+                                                  secret.
+                                                type: string
+                                              namespace:
+                                                description: |-
+                                                  Namespace is the namespace in which the secret exists. Context of use
+                                                  determines the default value if left out (e.g., "default").
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          value:
+                                            description: |-
+                                              Value matches the exact value of the header. Can be specified either
+                                              alone or together with "Secret"; will be used as the header value if the
+                                              secret can not be found in the latter case.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    headers:
+                                      description: |-
+                                        Headers is a list of HTTP headers which must be present in the
+                                        request. If omitted or empty, requests are allowed regardless of
+                                        headers present.
+                                      items:
+                                        type: string
+                                      type: array
+                                    host:
+                                      description: |-
+                                        Host is an extended POSIX regex matched against the host header of a
+                                        request. Examples:
+
+                                        - foo.bar.com will match the host fooXbar.com or foo-bar.com
+                                        - foo\.bar\.com will only match the host foo.bar.com
+
+                                        If omitted or empty, the value of the host header is ignored.
+                                      format: idn-hostname
+                                      type: string
+                                    method:
+                                      description: |-
+                                        Method is an extended POSIX regex matched against the method of a
+                                        request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                                        If omitted or empty, all methods are allowed.
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path is an extended POSIX regex matched against the path of a
+                                        request. Currently it can contain characters disallowed from the
+                                        conventional "path" part of a URL as defined by RFC 3986.
+
+                                        If omitted or empty, all paths are all allowed.
+                                      type: string
+                                  type: object
+                                type: array
+                              kafka:
+                                description: Kafka-specific rules.
+                                items:
+                                  description: |-
+                                    PortRule is a list of Kafka protocol constraints. All fields are
+                                    optional, if all fields are empty or missing, the rule will match all
+                                    Kafka messages.
+                                  properties:
+                                    apiKey:
+                                      description: |-
+                                        APIKey is a case-insensitive string matched against the key of a
+                                        request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al
+                                        Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                                        If omitted or empty, and if Role is not specified, then all keys are allowed.
+                                      type: string
+                                    apiVersion:
+                                      description: |-
+                                        APIVersion is the version matched against the api version of the
+                                        Kafka message. If set, it has to be a string representing a positive
+                                        integer.
+
+                                        If omitted or empty, all versions are allowed.
+                                      type: string
+                                    clientID:
+                                      description: |-
+                                        ClientID is the client identifier as provided in the request.
+
+                                        From Kafka protocol documentation:
+                                        This is a user supplied identifier for the client application. The
+                                        user can use any identifier they like and it will be used when
+                                        logging errors, monitoring aggregates, etc. For example, one might
+                                        want to monitor not just the requests per second overall, but the
+                                        number coming from each client application (each of which could
+                                        reside on multiple servers). This id acts as a logical grouping
+                                        across all requests from a particular client.
+
+                                        If omitted or empty, all client identifiers are allowed.
+                                      type: string
+                                    role:
+                                      description: |-
+                                        Role is a case-insensitive string and describes a group of API keys
+                                        necessary to perform certain higher-level Kafka operations such as "produce"
+                                        or "consume". A Role automatically expands into all APIKeys required
+                                        to perform the specified higher-level operation.
+
+                                        The following values are supported:
+                                         - "produce": Allow producing to the topics specified in the rule
+                                         - "consume": Allow consuming from the topics specified in the rule
+
+                                        This field is incompatible with the APIKey field, i.e APIKey and Role
+                                        cannot both be specified in the same rule.
+
+                                        If omitted or empty, and if APIKey is not specified, then all keys are
+                                        allowed.
+                                      enum:
+                                      - produce
+                                      - consume
+                                      type: string
+                                    topic:
+                                      description: |-
+                                        Topic is the topic name contained in the message. If a Kafka request
+                                        contains multiple topics, then all topics must be allowed or the
+                                        message will be rejected.
+
+                                        This constraint is ignored if the matched request message type
+                                        doesn't contain any topic. Maximum size of Topic can be 249
+                                        characters as per recent Kafka spec and allowed characters are
+                                        a-z, A-Z, 0-9, -, . and _.
+
+                                        Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10
+                                        version the length was changed from 255 to 249. For compatibility
+                                        reasons we are using 255.
+
+                                        If omitted or empty, all topics are allowed.
+                                      maxLength: 255
+                                      type: string
+                                  type: object
+                                type: array
+                              l7:
+                                description: Key-value pair rules.
+                                items:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    PortRuleL7 is a list of key-value pairs interpreted by a L7 protocol as
+                                    protocol constraints. All fields are optional, if all fields are empty or
+                                    missing, the rule does not have any effect.
+                                  type: object
+                                type: array
+                              l7proto:
+                                description: Name of the L7 protocol for which the
+                                  Key-value pair rules apply.
+                                type: string
+                            type: object
+                          serverNames:
+                            description: |-
+                              ServerNames is a list of allowed TLS SNI values. If not empty, then
+                              TLS must be present and one of the provided SNIs must be indicated in the
+                              TLS handshake.
+                            items:
+                              type: string
+                            type: array
+                          terminatingTLS:
+                            description: |-
+                              TerminatingTLS is the TLS context for the connection terminated by
+                              the L7 proxy.  For egress policy this specifies the server-side TLS
+                              parameters to be applied on the connections originated from the local
+                              endpoint and terminated by the L7 proxy. For ingress policy this specifies
+                              the server-side TLS parameters to be applied on the connections
+                              originated from a remote source and terminated by the L7 proxy.
+                            properties:
+                              certificate:
+                                description: |-
+                                  Certificate is the file name or k8s secret item name for the certificate
+                                  chain. If omitted, 'tls.crt' is assumed, if it exists. If given, the
+                                  item must exist.
+                                type: string
+                              privateKey:
+                                description: |-
+                                  PrivateKey is the file name or k8s secret item name for the private key
+                                  matching the certificate chain. If omitted, 'tls.key' is assumed, if it
+                                  exists. If given, the item must exist.
+                                type: string
+                              secret:
+                                description: |-
+                                  Secret is the secret that contains the certificates and private key for
+                                  the TLS context.
+                                  By default, Cilium will search in this secret for the following items:
+                                   - 'ca.crt'  - Which represents the trusted CA to verify remote source.
+                                   - 'tls.crt' - Which represents the public key certificate.
+                                   - 'tls.key' - Which represents the private key matching the public key
+                                                 certificate.
+                                properties:
+                                  name:
+                                    description: Name is the name of the secret.
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace in which the secret exists. Context of use
+                                      determines the default value if left out (e.g., "default").
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              trustedCA:
+                                description: |-
+                                  TrustedCA is the file name or k8s secret item name for the trusted CA.
+                                  If omitted, 'ca.crt' is assumed, if it exists. If given, the item must
+                                  exist.
+                                type: string
+                            required:
+                            - secret
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              ingressDeny:
+                description: |-
+                  IngressDeny is a list of IngressDenyRule which are enforced at ingress.
+                  Any rule inserted here will be denied regardless of the allowed ingress
+                  rules in the 'ingress' field.
+                  If omitted or empty, this rule does not apply at ingress.
+                items:
+                  description: |-
+                    IngressDenyRule contains all rule types which can be applied at ingress,
+                    i.e. network traffic that originates outside of the endpoint and
+                    is entering the endpoint selected by the endpointSelector.
+
+                      - All members of this structure are optional. If omitted or empty, the
+                        member will have no effect on the rule.
+
+                      - If multiple members are set, all of them need to match in order for
+                        the rule to take effect. The exception to this rule is FromRequires field;
+                        the effects of any Requires field in any rule will apply to all other
+                        rules as well.
+
+                      - FromEndpoints, FromCIDR, FromCIDRSet, FromGroups and FromEntities are mutually
+                        exclusive. Only one of these members may be present within an individual
+                        rule.
+                  properties:
+                    fromCIDR:
+                      description: |-
+                        FromCIDR is a list of IP blocks which the endpoint subject to the
+                        rule is allowed to receive connections from. Only connections which
+                        do *not* originate from the cluster or from the local host are subject
+                        to CIDR rules. In order to allow in-cluster connectivity, use the
+                        FromEndpoints field.  This will match on the source IP address of
+                        incoming connections. Adding  a prefix into FromCIDR or into
+                        FromCIDRSet with no ExcludeCIDRs is  equivalent.  Overlaps are
+                        allowed between FromCIDR and FromCIDRSet.
+
+                        Example:
+                        Any endpoint with the label "app=my-legacy-pet" is allowed to receive
+                        connections from 10.3.9.1
+                      items:
+                        description: |-
+                          CIDR specifies a block of IP addresses.
+                          Example: 192.0.2.1/32
+                        format: cidr
+                        type: string
+                      type: array
+                    fromCIDRSet:
+                      description: |-
+                        FromCIDRSet is a list of IP blocks which the endpoint subject to the
+                        rule is allowed to receive connections from in addition to FromEndpoints,
+                        along with a list of subnets contained within their corresponding IP block
+                        from which traffic should not be allowed.
+                        This will match on the source IP address of incoming connections. Adding
+                        a prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is
+                        equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+
+                        Example:
+                        Any endpoint with the label "app=my-legacy-pet" is allowed to receive
+                        connections from 10.0.0.0/8 except from IPs in subnet 10.96.0.0/12.
+                      items:
+                        description: |-
+                          CIDRRule is a rule that specifies a CIDR prefix to/from which outside
+                          communication  is allowed, along with an optional list of subnets within that
+                          CIDR prefix to/from which outside communication is not allowed.
+                        oneOf:
+                        - properties:
+                            cidr: {}
+                          required:
+                          - cidr
+                        - properties:
+                            cidrGroupRef: {}
+                          required:
+                          - cidrGroupRef
+                        - properties:
+                            cidrGroupSelector: {}
+                          required:
+                          - cidrGroupSelector
+                        properties:
+                          cidr:
+                            description: CIDR is a CIDR prefix / IP Block.
+                            format: cidr
+                            type: string
+                          cidrGroupRef:
+                            description: |-
+                              CIDRGroupRef is a reference to a CiliumCIDRGroup object.
+                              A CiliumCIDRGroup contains a list of CIDRs that the endpoint, subject to
+                              the rule, can (Ingress/Egress) or cannot (IngressDeny/EgressDeny) receive
+                              connections from.
+                            maxLength: 253
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          cidrGroupSelector:
+                            description: |-
+                              CIDRGroupSelector selects CiliumCIDRGroups by their labels,
+                              rather than by name.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  description: MatchLabelsValue represents the value
+                                    from the MatchLabels {key,value} pair.
+                                  maxLength: 63
+                                  pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          except:
+                            description: |-
+                              ExceptCIDRs is a list of IP blocks which the endpoint subject to the rule
+                              is not allowed to initiate connections to. These CIDR prefixes should be
+                              contained within Cidr, using ExceptCIDRs together with CIDRGroupRef is not
+                              supported yet.
+                              These exceptions are only applied to the Cidr in this CIDRRule, and do not
+                              apply to any other CIDR prefixes in any other CIDRRules.
+                            items:
+                              description: |-
+                                CIDR specifies a block of IP addresses.
+                                Example: 192.0.2.1/32
+                              format: cidr
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    fromEndpoints:
+                      description: |-
+                        FromEndpoints is a list of endpoints identified by an
+                        EndpointSelector which are allowed to communicate with the endpoint
+                        subject to the rule.
+
+                        Example:
+                        Any endpoint with the label "role=backend" can be consumed by any
+                        endpoint carrying the label "role=frontend".
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    fromEntities:
+                      description: |-
+                        FromEntities is a list of special entities which the endpoint subject
+                        to the rule is allowed to receive connections from. Supported entities are
+                        `world`, `cluster` and `host`
+                      items:
+                        description: |-
+                          Entity specifies the class of receiver/sender endpoints that do not have
+                          individual identities.  Entities are used to describe "outside of cluster",
+                          "host", etc.
+                        enum:
+                        - all
+                        - world
+                        - cluster
+                        - host
+                        - init
+                        - ingress
+                        - unmanaged
+                        - remote-node
+                        - health
+                        - none
+                        - kube-apiserver
+                        type: string
+                      type: array
+                    fromGroups:
+                      description: |-
+                        FromGroups is a directive that allows the integration with multiple outside
+                        providers. Currently, only AWS is supported, and the rule can select by
+                        multiple sub directives:
+
+                        Example:
+                        FromGroups:
+                        - aws:
+                            securityGroupsIds:
+                            - 'sg-XXXXXXXXXXXXX'
+                      items:
+                        description: |-
+                          Groups structure to store all kinds of new integrations that needs a new
+                          derivative policy.
+                        properties:
+                          aws:
+                            description: AWSGroup is an structure that can be used
+                              to whitelisting information from AWS integration
+                            properties:
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              region:
+                                type: string
+                              securityGroupsIds:
+                                items:
+                                  type: string
+                                type: array
+                              securityGroupsNames:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                    fromNodes:
+                      description: |-
+                        FromNodes is a list of nodes identified by an
+                        EndpointSelector which are allowed to communicate with the endpoint
+                        subject to the rule.
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    fromRequires:
+                      description: |-
+                        FromRequires is a list of additional constraints which must be met
+                        in order for the selected endpoints to be reachable. These
+                        additional constraints do no by itself grant access privileges and
+                        must always be accompanied with at least one matching FromEndpoints.
+
+                        Example:
+                        Any Endpoint with the label "team=A" requires consuming endpoint
+                        to also carry the label "team=A".
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    icmps:
+                      description: |-
+                        ICMPs is a list of ICMP rule identified by type number
+                        which the endpoint subject to the rule is not allowed to
+                        receive connections on.
+
+                        Example:
+                        Any endpoint with the label "app=httpd" can not accept incoming
+                        type 8 ICMP connections.
+                      items:
+                        description: ICMPRule is a list of ICMP fields.
+                        properties:
+                          fields:
+                            description: Fields is a list of ICMP fields.
+                            items:
+                              description: ICMPField is a ICMP field.
+                              properties:
+                                family:
+                                  default: IPv4
+                                  description: |-
+                                    Family is a IP address version.
+                                    Currently, we support `IPv4` and `IPv6`.
+                                    `IPv4` is set as default.
+                                  enum:
+                                  - IPv4
+                                  - IPv6
+                                  type: string
+                                type:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: "Type is a ICMP-type.\nIt should be
+                                    an 8bit code (0-255), or it's CamelCase name (for
+                                    example, \"EchoReply\").\nAllowed ICMP types are:\n
+                                    \   Ipv4: EchoReply | DestinationUnreachable |
+                                    Redirect | Echo | EchoRequest |\n\t\t     RouterAdvertisement
+                                    | RouterSelection | TimeExceeded | ParameterProblem
+                                    |\n\t\t\t Timestamp | TimestampReply | Photuris
+                                    | ExtendedEcho Request | ExtendedEcho Reply\n
+                                    \   Ipv6: DestinationUnreachable | PacketTooBig
+                                    | TimeExceeded | ParameterProblem |\n\t\t\t EchoRequest
+                                    | EchoReply | MulticastListenerQuery| MulticastListenerReport
+                                    |\n\t\t\t MulticastListenerDone | RouterSolicitation
+                                    | RouterAdvertisement | NeighborSolicitation |\n\t\t\t
+                                    NeighborAdvertisement | RedirectMessage | RouterRenumbering
+                                    | ICMPNodeInformationQuery |\n\t\t\t ICMPNodeInformationResponse
+                                    | InverseNeighborDiscoverySolicitation | InverseNeighborDiscoveryAdvertisement
+                                    |\n\t\t\t HomeAgentAddressDiscoveryRequest | HomeAgentAddressDiscoveryReply
+                                    | MobilePrefixSolicitation |\n\t\t\t MobilePrefixAdvertisement
+                                    | DuplicateAddressRequestCodeSuffix | DuplicateAddressConfirmationCodeSuffix
+                                    |\n\t\t\t ExtendedEchoRequest | ExtendedEchoReply"
+                                  pattern: ^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]|EchoReply|DestinationUnreachable|Redirect|Echo|RouterAdvertisement|RouterSelection|TimeExceeded|ParameterProblem|Timestamp|TimestampReply|Photuris|ExtendedEchoRequest|ExtendedEcho
+                                    Reply|PacketTooBig|ParameterProblem|EchoRequest|MulticastListenerQuery|MulticastListenerReport|MulticastListenerDone|RouterSolicitation|RouterAdvertisement|NeighborSolicitation|NeighborAdvertisement|RedirectMessage|RouterRenumbering|ICMPNodeInformationQuery|ICMPNodeInformationResponse|InverseNeighborDiscoverySolicitation|InverseNeighborDiscoveryAdvertisement|HomeAgentAddressDiscoveryRequest|HomeAgentAddressDiscoveryReply|MobilePrefixSolicitation|MobilePrefixAdvertisement|DuplicateAddressRequestCodeSuffix|DuplicateAddressConfirmationCodeSuffix)$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                            maxItems: 40
+                            type: array
+                        type: object
+                      type: array
+                    toPorts:
+                      description: |-
+                        ToPorts is a list of destination ports identified by port number and
+                        protocol which the endpoint subject to the rule is not allowed to
+                        receive connections on.
+
+                        Example:
+                        Any endpoint with the label "app=httpd" can not accept incoming
+                        connections on port 80/tcp.
+                      items:
+                        description: |-
+                          PortDenyRule is a list of ports/protocol that should be used for deny
+                          policies. This structure lacks the L7Rules since it's not supported in deny
+                          policies.
+                        properties:
+                          ports:
+                            description: Ports is a list of L4 port/protocol
+                            items:
+                              description: PortProtocol specifies an L4 port with
+                                an optional transport protocol
+                              properties:
+                                endPort:
+                                  description: EndPort can only be an L4 port number.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 0
+                                  type: integer
+                                port:
+                                  description: |-
+                                    Port can be an L4 port number, or a name in the form of "http"
+                                    or "http-8080".
+                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                  type: string
+                                protocol:
+                                  description: |-
+                                    Protocol is the L4 protocol. If omitted or empty, any protocol
+                                    matches. Accepted values: "TCP", "UDP", "SCTP", "ANY"
+
+                                    Matching on ICMP is not supported.
+
+                                    Named port specified for a container may narrow this down, but may not
+                                    contradict this.
+                                  enum:
+                                  - TCP
+                                  - UDP
+                                  - SCTP
+                                  - ANY
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              labels:
+                description: |-
+                  Labels is a list of optional strings which can be used to
+                  re-identify the rule or to store metadata. It is possible to lookup
+                  or delete strings based on labels. Labels are not required to be
+                  unique, multiple rules can have overlapping or identical labels.
+                items:
+                  description: Label is the Cilium's representation of a container
+                    label.
+                  properties:
+                    key:
+                      type: string
+                    source:
+                      description: 'Source can be one of the above values (e.g.: LabelSourceContainer).'
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - key
+                  type: object
+                type: array
+              nodeSelector:
+                description: |-
+                  NodeSelector selects all nodes which should be subject to this rule.
+                  EndpointSelector and NodeSelector cannot be both empty and are mutually
+                  exclusive. Can only be used in CiliumClusterwideNetworkPolicies.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            type: object
+          specs:
+            description: Specs is a list of desired Cilium specific rule specification.
+            items:
+              anyOf:
+              - properties:
+                  ingress: {}
+                required:
+                - ingress
+              - properties:
+                  ingressDeny: {}
+                required:
+                - ingressDeny
+              - properties:
+                  egress: {}
+                required:
+                - egress
+              - properties:
+                  egressDeny: {}
+                required:
+                - egressDeny
+              description: |-
+                Rule is a policy rule which must be applied to all endpoints which match the
+                labels contained in the endpointSelector
+
+                Each rule is split into an ingress section which contains all rules
+                applicable at ingress, and an egress section applicable at egress. For rule
+                types such as `L4Rule` and `CIDR` which can be applied at both ingress and
+                egress, both ingress and egress side have to either specifically allow the
+                connection or one side has to be omitted.
+
+                Either ingress, egress, or both can be provided. If both ingress and egress
+                are omitted, the rule has no effect.
+              oneOf:
+              - properties:
+                  endpointSelector: {}
+                required:
+                - endpointSelector
+              - properties:
+                  nodeSelector: {}
+                required:
+                - nodeSelector
+              properties:
+                description:
+                  description: |-
+                    Description is a free form string, it can be used by the creator of
+                    the rule to store human readable explanation of the purpose of this
+                    rule. Rules cannot be identified by comment.
+                  type: string
+                egress:
+                  description: |-
+                    Egress is a list of EgressRule which are enforced at egress.
+                    If omitted or empty, this rule does not apply at egress.
+                  items:
+                    description: |-
+                      EgressRule contains all rule types which can be applied at egress, i.e.
+                      network traffic that originates inside the endpoint and exits the endpoint
+                      selected by the endpointSelector.
+
+                        - All members of this structure are optional. If omitted or empty, the
+                          member will have no effect on the rule.
+
+                        - If multiple members of the structure are specified, then all members
+                          must match in order for the rule to take effect. The exception to this
+                          rule is the ToRequires member; the effects of any Requires field in any
+                          rule will apply to all other rules as well.
+
+                        - ToEndpoints, ToCIDR, ToCIDRSet, ToEntities, ToServices and ToGroups are
+                          mutually exclusive. Only one of these members may be present within an
+                          individual rule.
+                    properties:
+                      authentication:
+                        description: Authentication is the required authentication
+                          type for the allowed traffic, if any.
+                        properties:
+                          mode:
+                            description: Mode is the required authentication mode
+                              for the allowed traffic, if any.
+                            enum:
+                            - disabled
+                            - required
+                            - test-always-fail
+                            type: string
+                        required:
+                        - mode
+                        type: object
+                      icmps:
+                        description: |-
+                          ICMPs is a list of ICMP rule identified by type number
+                          which the endpoint subject to the rule is allowed to connect to.
+
+                          Example:
+                          Any endpoint with the label "app=httpd" is allowed to initiate
+                          type 8 ICMP connections.
+                        items:
+                          description: ICMPRule is a list of ICMP fields.
+                          properties:
+                            fields:
+                              description: Fields is a list of ICMP fields.
+                              items:
+                                description: ICMPField is a ICMP field.
+                                properties:
+                                  family:
+                                    default: IPv4
+                                    description: |-
+                                      Family is a IP address version.
+                                      Currently, we support `IPv4` and `IPv6`.
+                                      `IPv4` is set as default.
+                                    enum:
+                                    - IPv4
+                                    - IPv6
+                                    type: string
+                                  type:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: "Type is a ICMP-type.\nIt should
+                                      be an 8bit code (0-255), or it's CamelCase name
+                                      (for example, \"EchoReply\").\nAllowed ICMP
+                                      types are:\n    Ipv4: EchoReply | DestinationUnreachable
+                                      | Redirect | Echo | EchoRequest |\n\t\t     RouterAdvertisement
+                                      | RouterSelection | TimeExceeded | ParameterProblem
+                                      |\n\t\t\t Timestamp | TimestampReply | Photuris
+                                      | ExtendedEcho Request | ExtendedEcho Reply\n
+                                      \   Ipv6: DestinationUnreachable | PacketTooBig
+                                      | TimeExceeded | ParameterProblem |\n\t\t\t
+                                      EchoRequest | EchoReply | MulticastListenerQuery|
+                                      MulticastListenerReport |\n\t\t\t MulticastListenerDone
+                                      | RouterSolicitation | RouterAdvertisement |
+                                      NeighborSolicitation |\n\t\t\t NeighborAdvertisement
+                                      | RedirectMessage | RouterRenumbering | ICMPNodeInformationQuery
+                                      |\n\t\t\t ICMPNodeInformationResponse | InverseNeighborDiscoverySolicitation
+                                      | InverseNeighborDiscoveryAdvertisement |\n\t\t\t
+                                      HomeAgentAddressDiscoveryRequest | HomeAgentAddressDiscoveryReply
+                                      | MobilePrefixSolicitation |\n\t\t\t MobilePrefixAdvertisement
+                                      | DuplicateAddressRequestCodeSuffix | DuplicateAddressConfirmationCodeSuffix
+                                      |\n\t\t\t ExtendedEchoRequest | ExtendedEchoReply"
+                                    pattern: ^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]|EchoReply|DestinationUnreachable|Redirect|Echo|RouterAdvertisement|RouterSelection|TimeExceeded|ParameterProblem|Timestamp|TimestampReply|Photuris|ExtendedEchoRequest|ExtendedEcho
+                                      Reply|PacketTooBig|ParameterProblem|EchoRequest|MulticastListenerQuery|MulticastListenerReport|MulticastListenerDone|RouterSolicitation|RouterAdvertisement|NeighborSolicitation|NeighborAdvertisement|RedirectMessage|RouterRenumbering|ICMPNodeInformationQuery|ICMPNodeInformationResponse|InverseNeighborDiscoverySolicitation|InverseNeighborDiscoveryAdvertisement|HomeAgentAddressDiscoveryRequest|HomeAgentAddressDiscoveryReply|MobilePrefixSolicitation|MobilePrefixAdvertisement|DuplicateAddressRequestCodeSuffix|DuplicateAddressConfirmationCodeSuffix)$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - type
+                                type: object
+                              maxItems: 40
+                              type: array
+                          type: object
+                        type: array
+                      toCIDR:
+                        description: |-
+                          ToCIDR is a list of IP blocks which the endpoint subject to the rule
+                          is allowed to initiate connections. Only connections destined for
+                          outside of the cluster and not targeting the host will be subject
+                          to CIDR rules.  This will match on the destination IP address of
+                          outgoing connections. Adding a prefix into ToCIDR or into ToCIDRSet
+                          with no ExcludeCIDRs is equivalent. Overlaps are allowed between
+                          ToCIDR and ToCIDRSet.
+
+                          Example:
+                          Any endpoint with the label "app=database-proxy" is allowed to
+                          initiate connections to 10.2.3.0/24
+                        items:
+                          description: |-
+                            CIDR specifies a block of IP addresses.
+                            Example: 192.0.2.1/32
+                          format: cidr
+                          type: string
+                        type: array
+                      toCIDRSet:
+                        description: |-
+                          ToCIDRSet is a list of IP blocks which the endpoint subject to the rule
+                          is allowed to initiate connections to in addition to connections
+                          which are allowed via ToEndpoints, along with a list of subnets contained
+                          within their corresponding IP block to which traffic should not be
+                          allowed. This will match on the destination IP address of outgoing
+                          connections. Adding a prefix into ToCIDR or into ToCIDRSet with no
+                          ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and
+                          ToCIDRSet.
+
+                          Example:
+                          Any endpoint with the label "app=database-proxy" is allowed to
+                          initiate connections to 10.2.3.0/24 except from IPs in subnet 10.2.3.0/28.
+                        items:
+                          description: |-
+                            CIDRRule is a rule that specifies a CIDR prefix to/from which outside
+                            communication  is allowed, along with an optional list of subnets within that
+                            CIDR prefix to/from which outside communication is not allowed.
+                          oneOf:
+                          - properties:
+                              cidr: {}
+                            required:
+                            - cidr
+                          - properties:
+                              cidrGroupRef: {}
+                            required:
+                            - cidrGroupRef
+                          - properties:
+                              cidrGroupSelector: {}
+                            required:
+                            - cidrGroupSelector
+                          properties:
+                            cidr:
+                              description: CIDR is a CIDR prefix / IP Block.
+                              format: cidr
+                              type: string
+                            cidrGroupRef:
+                              description: |-
+                                CIDRGroupRef is a reference to a CiliumCIDRGroup object.
+                                A CiliumCIDRGroup contains a list of CIDRs that the endpoint, subject to
+                                the rule, can (Ingress/Egress) or cannot (IngressDeny/EgressDeny) receive
+                                connections from.
+                              maxLength: 253
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            cidrGroupSelector:
+                              description: |-
+                                CIDRGroupSelector selects CiliumCIDRGroups by their labels,
+                                rather than by name.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        enum:
+                                        - In
+                                        - NotIn
+                                        - Exists
+                                        - DoesNotExist
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    description: MatchLabelsValue represents the value
+                                      from the MatchLabels {key,value} pair.
+                                    maxLength: 63
+                                    pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            except:
+                              description: |-
+                                ExceptCIDRs is a list of IP blocks which the endpoint subject to the rule
+                                is not allowed to initiate connections to. These CIDR prefixes should be
+                                contained within Cidr, using ExceptCIDRs together with CIDRGroupRef is not
+                                supported yet.
+                                These exceptions are only applied to the Cidr in this CIDRRule, and do not
+                                apply to any other CIDR prefixes in any other CIDRRules.
+                              items:
+                                description: |-
+                                  CIDR specifies a block of IP addresses.
+                                  Example: 192.0.2.1/32
+                                format: cidr
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      toEndpoints:
+                        description: |-
+                          ToEndpoints is a list of endpoints identified by an EndpointSelector to
+                          which the endpoints subject to the rule are allowed to communicate.
+
+                          Example:
+                          Any endpoint with the label "role=frontend" can communicate with any
+                          endpoint carrying the label "role=backend".
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      toEntities:
+                        description: |-
+                          ToEntities is a list of special entities to which the endpoint subject
+                          to the rule is allowed to initiate connections. Supported entities are
+                          `world`, `cluster`,`host`,`remote-node`,`kube-apiserver`, `init`,
+                          `health`,`unmanaged` and `all`.
+                        items:
+                          description: |-
+                            Entity specifies the class of receiver/sender endpoints that do not have
+                            individual identities.  Entities are used to describe "outside of cluster",
+                            "host", etc.
+                          enum:
+                          - all
+                          - world
+                          - cluster
+                          - host
+                          - init
+                          - ingress
+                          - unmanaged
+                          - remote-node
+                          - health
+                          - none
+                          - kube-apiserver
+                          type: string
+                        type: array
+                      toFQDNs:
+                        description: |-
+                          ToFQDN allows whitelisting DNS names in place of IPs. The IPs that result
+                          from DNS resolution of `ToFQDN.MatchName`s are added to the same
+                          EgressRule object as ToCIDRSet entries, and behave accordingly. Any L4 and
+                          L7 rules within this EgressRule will also apply to these IPs.
+                          The DNS -> IP mapping is re-resolved periodically from within the
+                          cilium-agent, and the IPs in the DNS response are effected in the policy
+                          for selected pods as-is (i.e. the list of IPs is not modified in any way).
+                          Note: An explicit rule to allow for DNS traffic is needed for the pods, as
+                          ToFQDN counts as an egress rule and will enforce egress policy when
+                          PolicyEnforcment=default.
+                          Note: If the resolved IPs are IPs within the kubernetes cluster, the
+                          ToFQDN rule will not apply to that IP.
+                          Note: ToFQDN cannot occur in the same policy as other To* rules.
+                        items:
+                          oneOf:
+                          - properties:
+                              matchName: {}
+                            required:
+                            - matchName
+                          - properties:
+                              matchPattern: {}
+                            required:
+                            - matchPattern
+                          properties:
+                            matchName:
+                              description: |-
+                                MatchName matches literal DNS names. A trailing "." is automatically added
+                                when missing.
+                              maxLength: 255
+                              pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                              type: string
+                            matchPattern:
+                              description: |-
+                                MatchPattern allows using wildcards to match DNS names. All wildcards are
+                                case insensitive. The wildcards are:
+                                - "*" matches 0 or more DNS valid characters, and may occur anywhere in
+                                the pattern. As a special case a "*" as the leftmost character, without a
+                                following "." matches all subdomains as well as the name to the right.
+                                A trailing "." is automatically added when missing.
+
+                                Examples:
+                                `*.cilium.io` matches subomains of cilium at that level
+                                  www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
+                                `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                  except those containing "." separator, subcilium.io and sub-cilium.io match,
+                                  www.cilium.io and blog.cilium.io does not
+                                sub*.cilium.io matches subdomains of cilium where the subdomain component
+                                begins with "sub"
+                                  sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                  blog.cilium.io, cilium.io and google.com do not
+                              maxLength: 255
+                              pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                              type: string
+                          type: object
+                        type: array
+                      toGroups:
+                        description: |-
+                          ToGroups is a directive that allows the integration with multiple outside
+                          providers. Currently, only AWS is supported, and the rule can select by
+                          multiple sub directives:
+
+                          Example:
+                          toGroups:
+                          - aws:
+                              securityGroupsIds:
+                              - 'sg-XXXXXXXXXXXXX'
+                        items:
+                          description: |-
+                            Groups structure to store all kinds of new integrations that needs a new
+                            derivative policy.
+                          properties:
+                            aws:
+                              description: AWSGroup is an structure that can be used
+                                to whitelisting information from AWS integration
+                              properties:
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                region:
+                                  type: string
+                                securityGroupsIds:
+                                  items:
+                                    type: string
+                                  type: array
+                                securityGroupsNames:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      toNodes:
+                        description: |-
+                          ToNodes is a list of nodes identified by an
+                          EndpointSelector to which endpoints subject to the rule is allowed to communicate.
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      toPorts:
+                        description: |-
+                          ToPorts is a list of destination ports identified by port number and
+                          protocol which the endpoint subject to the rule is allowed to
+                          connect to.
+
+                          Example:
+                          Any endpoint with the label "role=frontend" is allowed to initiate
+                          connections to destination port 8080/tcp
+                        items:
+                          description: |-
+                            PortRule is a list of ports/protocol combinations with optional Layer 7
+                            rules which must be met.
+                          properties:
+                            listener:
+                              description: |-
+                                listener specifies the name of a custom Envoy listener to which this traffic should be
+                                redirected to.
+                              properties:
+                                envoyConfig:
+                                  description: |-
+                                    EnvoyConfig is a reference to the CEC or CCEC resource in which
+                                    the listener is defined.
+                                  properties:
+                                    kind:
+                                      description: |-
+                                        Kind is the resource type being referred to. Defaults to CiliumEnvoyConfig or
+                                        CiliumClusterwideEnvoyConfig for CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy,
+                                        respectively. The only case this is currently explicitly needed is when referring to a
+                                        CiliumClusterwideEnvoyConfig from CiliumNetworkPolicy, as using a namespaced listener
+                                        from a cluster scoped policy is not allowed.
+                                      enum:
+                                      - CiliumEnvoyConfig
+                                      - CiliumClusterwideEnvoyConfig
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name is the resource name of the CiliumEnvoyConfig or CiliumClusterwideEnvoyConfig where
+                                        the listener is defined in.
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                name:
+                                  description: Name is the name of the listener.
+                                  minLength: 1
+                                  type: string
+                                priority:
+                                  description: |-
+                                    Priority for this Listener that is used when multiple rules would apply different
+                                    listeners to a policy map entry. Behavior of this is implementation dependent.
+                                  maximum: 100
+                                  minimum: 1
+                                  type: integer
+                              required:
+                              - envoyConfig
+                              - name
+                              type: object
+                            originatingTLS:
+                              description: |-
+                                OriginatingTLS is the TLS context for the connections originated by
+                                the L7 proxy.  For egress policy this specifies the client-side TLS
+                                parameters for the upstream connection originating from the L7 proxy
+                                to the remote destination. For ingress policy this specifies the
+                                client-side TLS parameters for the connection from the L7 proxy to
+                                the local endpoint.
+                              properties:
+                                certificate:
+                                  description: |-
+                                    Certificate is the file name or k8s secret item name for the certificate
+                                    chain. If omitted, 'tls.crt' is assumed, if it exists. If given, the
+                                    item must exist.
+                                  type: string
+                                privateKey:
+                                  description: |-
+                                    PrivateKey is the file name or k8s secret item name for the private key
+                                    matching the certificate chain. If omitted, 'tls.key' is assumed, if it
+                                    exists. If given, the item must exist.
+                                  type: string
+                                secret:
+                                  description: |-
+                                    Secret is the secret that contains the certificates and private key for
+                                    the TLS context.
+                                    By default, Cilium will search in this secret for the following items:
+                                     - 'ca.crt'  - Which represents the trusted CA to verify remote source.
+                                     - 'tls.crt' - Which represents the public key certificate.
+                                     - 'tls.key' - Which represents the private key matching the public key
+                                                   certificate.
+                                  properties:
+                                    name:
+                                      description: Name is the name of the secret.
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace in which the secret exists. Context of use
+                                        determines the default value if left out (e.g., "default").
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                trustedCA:
+                                  description: |-
+                                    TrustedCA is the file name or k8s secret item name for the trusted CA.
+                                    If omitted, 'ca.crt' is assumed, if it exists. If given, the item must
+                                    exist.
+                                  type: string
+                              required:
+                              - secret
+                              type: object
+                            ports:
+                              description: Ports is a list of L4 port/protocol
+                              items:
+                                description: PortProtocol specifies an L4 port with
+                                  an optional transport protocol
+                                properties:
+                                  endPort:
+                                    description: EndPort can only be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
+                                  port:
+                                    description: |-
+                                      Port can be an L4 port number, or a name in the form of "http"
+                                      or "http-8080".
+                                    pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                    type: string
+                                  protocol:
+                                    description: |-
+                                      Protocol is the L4 protocol. If omitted or empty, any protocol
+                                      matches. Accepted values: "TCP", "UDP", "SCTP", "ANY"
+
+                                      Matching on ICMP is not supported.
+
+                                      Named port specified for a container may narrow this down, but may not
+                                      contradict this.
+                                    enum:
+                                    - TCP
+                                    - UDP
+                                    - SCTP
+                                    - ANY
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              maxItems: 40
+                              type: array
+                            rules:
+                              description: |-
+                                Rules is a list of additional port level rules which must be met in
+                                order for the PortRule to allow the traffic. If omitted or empty,
+                                no layer 7 rules are enforced.
+                              oneOf:
+                              - properties:
+                                  http: {}
+                                required:
+                                - http
+                              - properties:
+                                  kafka: {}
+                                required:
+                                - kafka
+                              - properties:
+                                  dns: {}
+                                required:
+                                - dns
+                              - properties:
+                                  l7proto: {}
+                                required:
+                                - l7proto
+                              properties:
+                                dns:
+                                  description: DNS-specific rules.
+                                  items:
+                                    description: PortRuleDNS is a list of allowed
+                                      DNS lookups.
+                                    oneOf:
+                                    - properties:
+                                        matchName: {}
+                                      required:
+                                      - matchName
+                                    - properties:
+                                        matchPattern: {}
+                                      required:
+                                      - matchPattern
+                                    properties:
+                                      matchName:
+                                        description: |-
+                                          MatchName matches literal DNS names. A trailing "." is automatically added
+                                          when missing.
+                                        maxLength: 255
+                                        pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                                        type: string
+                                      matchPattern:
+                                        description: |-
+                                          MatchPattern allows using wildcards to match DNS names. All wildcards are
+                                          case insensitive. The wildcards are:
+                                          - "*" matches 0 or more DNS valid characters, and may occur anywhere in
+                                          the pattern. As a special case a "*" as the leftmost character, without a
+                                          following "." matches all subdomains as well as the name to the right.
+                                          A trailing "." is automatically added when missing.
+
+                                          Examples:
+                                          `*.cilium.io` matches subomains of cilium at that level
+                                            www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
+                                          `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                            except those containing "." separator, subcilium.io and sub-cilium.io match,
+                                            www.cilium.io and blog.cilium.io does not
+                                          sub*.cilium.io matches subdomains of cilium where the subdomain component
+                                          begins with "sub"
+                                            sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                            blog.cilium.io, cilium.io and google.com do not
+                                        maxLength: 255
+                                        pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                                        type: string
+                                    type: object
+                                  type: array
+                                http:
+                                  description: HTTP specific rules.
+                                  items:
+                                    description: |-
+                                      PortRuleHTTP is a list of HTTP protocol constraints. All fields are
+                                      optional, if all fields are empty or missing, the rule does not have any
+                                      effect.
+
+                                      All fields of this type are extended POSIX regex as defined by IEEE Std
+                                      1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax)
+                                      matched against the path of an incoming request. Currently it can contain
+                                      characters disallowed from the conventional "path" part of a URL as defined
+                                      by RFC 3986.
+                                    properties:
+                                      headerMatches:
+                                        description: |-
+                                          HeaderMatches is a list of HTTP headers which must be
+                                          present and match against the given values. Mismatch field can be used
+                                          to specify what to do when there is no match.
+                                        items:
+                                          description: |-
+                                            HeaderMatch extends the HeaderValue for matching requirement of a
+                                            named header field against an immediate string, a secret value, or
+                                            a regex.  If none of the optional fields is present, then the
+                                            header value is not matched, only presence of the header is enough.
+                                          properties:
+                                            mismatch:
+                                              description: |-
+                                                Mismatch identifies what to do in case there is no match. The default is
+                                                to drop the request. Otherwise the overall rule is still considered as
+                                                matching, but the mismatches are logged in the access log.
+                                              enum:
+                                              - LOG
+                                              - ADD
+                                              - DELETE
+                                              - REPLACE
+                                              type: string
+                                            name:
+                                              description: Name identifies the header.
+                                              minLength: 1
+                                              type: string
+                                            secret:
+                                              description: |-
+                                                Secret refers to a secret that contains the value to be matched against.
+                                                The secret must only contain one entry. If the referred secret does not
+                                                exist, and there is no "Value" specified, the match will fail.
+                                              properties:
+                                                name:
+                                                  description: Name is the name of
+                                                    the secret.
+                                                  type: string
+                                                namespace:
+                                                  description: |-
+                                                    Namespace is the namespace in which the secret exists. Context of use
+                                                    determines the default value if left out (e.g., "default").
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            value:
+                                              description: |-
+                                                Value matches the exact value of the header. Can be specified either
+                                                alone or together with "Secret"; will be used as the header value if the
+                                                secret can not be found in the latter case.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      headers:
+                                        description: |-
+                                          Headers is a list of HTTP headers which must be present in the
+                                          request. If omitted or empty, requests are allowed regardless of
+                                          headers present.
+                                        items:
+                                          type: string
+                                        type: array
+                                      host:
+                                        description: |-
+                                          Host is an extended POSIX regex matched against the host header of a
+                                          request. Examples:
+
+                                          - foo.bar.com will match the host fooXbar.com or foo-bar.com
+                                          - foo\.bar\.com will only match the host foo.bar.com
+
+                                          If omitted or empty, the value of the host header is ignored.
+                                        format: idn-hostname
+                                        type: string
+                                      method:
+                                        description: |-
+                                          Method is an extended POSIX regex matched against the method of a
+                                          request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                                          If omitted or empty, all methods are allowed.
+                                        type: string
+                                      path:
+                                        description: |-
+                                          Path is an extended POSIX regex matched against the path of a
+                                          request. Currently it can contain characters disallowed from the
+                                          conventional "path" part of a URL as defined by RFC 3986.
+
+                                          If omitted or empty, all paths are all allowed.
+                                        type: string
+                                    type: object
+                                  type: array
+                                kafka:
+                                  description: Kafka-specific rules.
+                                  items:
+                                    description: |-
+                                      PortRule is a list of Kafka protocol constraints. All fields are
+                                      optional, if all fields are empty or missing, the rule will match all
+                                      Kafka messages.
+                                    properties:
+                                      apiKey:
+                                        description: |-
+                                          APIKey is a case-insensitive string matched against the key of a
+                                          request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al
+                                          Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                                          If omitted or empty, and if Role is not specified, then all keys are allowed.
+                                        type: string
+                                      apiVersion:
+                                        description: |-
+                                          APIVersion is the version matched against the api version of the
+                                          Kafka message. If set, it has to be a string representing a positive
+                                          integer.
+
+                                          If omitted or empty, all versions are allowed.
+                                        type: string
+                                      clientID:
+                                        description: |-
+                                          ClientID is the client identifier as provided in the request.
+
+                                          From Kafka protocol documentation:
+                                          This is a user supplied identifier for the client application. The
+                                          user can use any identifier they like and it will be used when
+                                          logging errors, monitoring aggregates, etc. For example, one might
+                                          want to monitor not just the requests per second overall, but the
+                                          number coming from each client application (each of which could
+                                          reside on multiple servers). This id acts as a logical grouping
+                                          across all requests from a particular client.
+
+                                          If omitted or empty, all client identifiers are allowed.
+                                        type: string
+                                      role:
+                                        description: |-
+                                          Role is a case-insensitive string and describes a group of API keys
+                                          necessary to perform certain higher-level Kafka operations such as "produce"
+                                          or "consume". A Role automatically expands into all APIKeys required
+                                          to perform the specified higher-level operation.
+
+                                          The following values are supported:
+                                           - "produce": Allow producing to the topics specified in the rule
+                                           - "consume": Allow consuming from the topics specified in the rule
+
+                                          This field is incompatible with the APIKey field, i.e APIKey and Role
+                                          cannot both be specified in the same rule.
+
+                                          If omitted or empty, and if APIKey is not specified, then all keys are
+                                          allowed.
+                                        enum:
+                                        - produce
+                                        - consume
+                                        type: string
+                                      topic:
+                                        description: |-
+                                          Topic is the topic name contained in the message. If a Kafka request
+                                          contains multiple topics, then all topics must be allowed or the
+                                          message will be rejected.
+
+                                          This constraint is ignored if the matched request message type
+                                          doesn't contain any topic. Maximum size of Topic can be 249
+                                          characters as per recent Kafka spec and allowed characters are
+                                          a-z, A-Z, 0-9, -, . and _.
+
+                                          Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10
+                                          version the length was changed from 255 to 249. For compatibility
+                                          reasons we are using 255.
+
+                                          If omitted or empty, all topics are allowed.
+                                        maxLength: 255
+                                        type: string
+                                    type: object
+                                  type: array
+                                l7:
+                                  description: Key-value pair rules.
+                                  items:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      PortRuleL7 is a list of key-value pairs interpreted by a L7 protocol as
+                                      protocol constraints. All fields are optional, if all fields are empty or
+                                      missing, the rule does not have any effect.
+                                    type: object
+                                  type: array
+                                l7proto:
+                                  description: Name of the L7 protocol for which the
+                                    Key-value pair rules apply.
+                                  type: string
+                              type: object
+                            serverNames:
+                              description: |-
+                                ServerNames is a list of allowed TLS SNI values. If not empty, then
+                                TLS must be present and one of the provided SNIs must be indicated in the
+                                TLS handshake.
+                              items:
+                                type: string
+                              type: array
+                            terminatingTLS:
+                              description: |-
+                                TerminatingTLS is the TLS context for the connection terminated by
+                                the L7 proxy.  For egress policy this specifies the server-side TLS
+                                parameters to be applied on the connections originated from the local
+                                endpoint and terminated by the L7 proxy. For ingress policy this specifies
+                                the server-side TLS parameters to be applied on the connections
+                                originated from a remote source and terminated by the L7 proxy.
+                              properties:
+                                certificate:
+                                  description: |-
+                                    Certificate is the file name or k8s secret item name for the certificate
+                                    chain. If omitted, 'tls.crt' is assumed, if it exists. If given, the
+                                    item must exist.
+                                  type: string
+                                privateKey:
+                                  description: |-
+                                    PrivateKey is the file name or k8s secret item name for the private key
+                                    matching the certificate chain. If omitted, 'tls.key' is assumed, if it
+                                    exists. If given, the item must exist.
+                                  type: string
+                                secret:
+                                  description: |-
+                                    Secret is the secret that contains the certificates and private key for
+                                    the TLS context.
+                                    By default, Cilium will search in this secret for the following items:
+                                     - 'ca.crt'  - Which represents the trusted CA to verify remote source.
+                                     - 'tls.crt' - Which represents the public key certificate.
+                                     - 'tls.key' - Which represents the private key matching the public key
+                                                   certificate.
+                                  properties:
+                                    name:
+                                      description: Name is the name of the secret.
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace in which the secret exists. Context of use
+                                        determines the default value if left out (e.g., "default").
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                trustedCA:
+                                  description: |-
+                                    TrustedCA is the file name or k8s secret item name for the trusted CA.
+                                    If omitted, 'ca.crt' is assumed, if it exists. If given, the item must
+                                    exist.
+                                  type: string
+                              required:
+                              - secret
+                              type: object
+                          type: object
+                        type: array
+                      toRequires:
+                        description: |-
+                          ToRequires is a list of additional constraints which must be met
+                          in order for the selected endpoints to be able to connect to other
+                          endpoints. These additional constraints do no by itself grant access
+                          privileges and must always be accompanied with at least one matching
+                          ToEndpoints.
+
+                          Example:
+                          Any Endpoint with the label "team=A" requires any endpoint to which it
+                          communicates to also carry the label "team=A".
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      toServices:
+                        description: |-
+                          ToServices is a list of services to which the endpoint subject
+                          to the rule is allowed to initiate connections.
+                          Currently Cilium only supports toServices for K8s services.
+                        items:
+                          description: |-
+                            Service selects policy targets that are bundled as part of a
+                            logical load-balanced service.
+
+                            Currently only Kubernetes-based Services are supported.
+                          properties:
+                            k8sService:
+                              description: K8sService selects service by name and
+                                namespace pair
+                              properties:
+                                namespace:
+                                  type: string
+                                serviceName:
+                                  type: string
+                              type: object
+                            k8sServiceSelector:
+                              description: K8sServiceSelector selects services by
+                                k8s labels and namespace
+                              properties:
+                                namespace:
+                                  type: string
+                                selector:
+                                  description: ServiceSelector is a label selector
+                                    for k8s services
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            enum:
+                                            - In
+                                            - NotIn
+                                            - Exists
+                                            - DoesNotExist
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        description: MatchLabelsValue represents the
+                                          value from the MatchLabels {key,value} pair.
+                                        maxLength: 63
+                                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - selector
+                              type: object
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+                egressDeny:
+                  description: |-
+                    EgressDeny is a list of EgressDenyRule which are enforced at egress.
+                    Any rule inserted here will be denied regardless of the allowed egress
+                    rules in the 'egress' field.
+                    If omitted or empty, this rule does not apply at egress.
+                  items:
+                    description: |-
+                      EgressDenyRule contains all rule types which can be applied at egress, i.e.
+                      network traffic that originates inside the endpoint and exits the endpoint
+                      selected by the endpointSelector.
+
+                        - All members of this structure are optional. If omitted or empty, the
+                          member will have no effect on the rule.
+
+                        - If multiple members of the structure are specified, then all members
+                          must match in order for the rule to take effect. The exception to this
+                          rule is the ToRequires member; the effects of any Requires field in any
+                          rule will apply to all other rules as well.
+
+                        - ToEndpoints, ToCIDR, ToCIDRSet, ToEntities, ToServices and ToGroups are
+                          mutually exclusive. Only one of these members may be present within an
+                          individual rule.
+                    properties:
+                      icmps:
+                        description: |-
+                          ICMPs is a list of ICMP rule identified by type number
+                          which the endpoint subject to the rule is not allowed to connect to.
+
+                          Example:
+                          Any endpoint with the label "app=httpd" is not allowed to initiate
+                          type 8 ICMP connections.
+                        items:
+                          description: ICMPRule is a list of ICMP fields.
+                          properties:
+                            fields:
+                              description: Fields is a list of ICMP fields.
+                              items:
+                                description: ICMPField is a ICMP field.
+                                properties:
+                                  family:
+                                    default: IPv4
+                                    description: |-
+                                      Family is a IP address version.
+                                      Currently, we support `IPv4` and `IPv6`.
+                                      `IPv4` is set as default.
+                                    enum:
+                                    - IPv4
+                                    - IPv6
+                                    type: string
+                                  type:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: "Type is a ICMP-type.\nIt should
+                                      be an 8bit code (0-255), or it's CamelCase name
+                                      (for example, \"EchoReply\").\nAllowed ICMP
+                                      types are:\n    Ipv4: EchoReply | DestinationUnreachable
+                                      | Redirect | Echo | EchoRequest |\n\t\t     RouterAdvertisement
+                                      | RouterSelection | TimeExceeded | ParameterProblem
+                                      |\n\t\t\t Timestamp | TimestampReply | Photuris
+                                      | ExtendedEcho Request | ExtendedEcho Reply\n
+                                      \   Ipv6: DestinationUnreachable | PacketTooBig
+                                      | TimeExceeded | ParameterProblem |\n\t\t\t
+                                      EchoRequest | EchoReply | MulticastListenerQuery|
+                                      MulticastListenerReport |\n\t\t\t MulticastListenerDone
+                                      | RouterSolicitation | RouterAdvertisement |
+                                      NeighborSolicitation |\n\t\t\t NeighborAdvertisement
+                                      | RedirectMessage | RouterRenumbering | ICMPNodeInformationQuery
+                                      |\n\t\t\t ICMPNodeInformationResponse | InverseNeighborDiscoverySolicitation
+                                      | InverseNeighborDiscoveryAdvertisement |\n\t\t\t
+                                      HomeAgentAddressDiscoveryRequest | HomeAgentAddressDiscoveryReply
+                                      | MobilePrefixSolicitation |\n\t\t\t MobilePrefixAdvertisement
+                                      | DuplicateAddressRequestCodeSuffix | DuplicateAddressConfirmationCodeSuffix
+                                      |\n\t\t\t ExtendedEchoRequest | ExtendedEchoReply"
+                                    pattern: ^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]|EchoReply|DestinationUnreachable|Redirect|Echo|RouterAdvertisement|RouterSelection|TimeExceeded|ParameterProblem|Timestamp|TimestampReply|Photuris|ExtendedEchoRequest|ExtendedEcho
+                                      Reply|PacketTooBig|ParameterProblem|EchoRequest|MulticastListenerQuery|MulticastListenerReport|MulticastListenerDone|RouterSolicitation|RouterAdvertisement|NeighborSolicitation|NeighborAdvertisement|RedirectMessage|RouterRenumbering|ICMPNodeInformationQuery|ICMPNodeInformationResponse|InverseNeighborDiscoverySolicitation|InverseNeighborDiscoveryAdvertisement|HomeAgentAddressDiscoveryRequest|HomeAgentAddressDiscoveryReply|MobilePrefixSolicitation|MobilePrefixAdvertisement|DuplicateAddressRequestCodeSuffix|DuplicateAddressConfirmationCodeSuffix)$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - type
+                                type: object
+                              maxItems: 40
+                              type: array
+                          type: object
+                        type: array
+                      toCIDR:
+                        description: |-
+                          ToCIDR is a list of IP blocks which the endpoint subject to the rule
+                          is allowed to initiate connections. Only connections destined for
+                          outside of the cluster and not targeting the host will be subject
+                          to CIDR rules.  This will match on the destination IP address of
+                          outgoing connections. Adding a prefix into ToCIDR or into ToCIDRSet
+                          with no ExcludeCIDRs is equivalent. Overlaps are allowed between
+                          ToCIDR and ToCIDRSet.
+
+                          Example:
+                          Any endpoint with the label "app=database-proxy" is allowed to
+                          initiate connections to 10.2.3.0/24
+                        items:
+                          description: |-
+                            CIDR specifies a block of IP addresses.
+                            Example: 192.0.2.1/32
+                          format: cidr
+                          type: string
+                        type: array
+                      toCIDRSet:
+                        description: |-
+                          ToCIDRSet is a list of IP blocks which the endpoint subject to the rule
+                          is allowed to initiate connections to in addition to connections
+                          which are allowed via ToEndpoints, along with a list of subnets contained
+                          within their corresponding IP block to which traffic should not be
+                          allowed. This will match on the destination IP address of outgoing
+                          connections. Adding a prefix into ToCIDR or into ToCIDRSet with no
+                          ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and
+                          ToCIDRSet.
+
+                          Example:
+                          Any endpoint with the label "app=database-proxy" is allowed to
+                          initiate connections to 10.2.3.0/24 except from IPs in subnet 10.2.3.0/28.
+                        items:
+                          description: |-
+                            CIDRRule is a rule that specifies a CIDR prefix to/from which outside
+                            communication  is allowed, along with an optional list of subnets within that
+                            CIDR prefix to/from which outside communication is not allowed.
+                          oneOf:
+                          - properties:
+                              cidr: {}
+                            required:
+                            - cidr
+                          - properties:
+                              cidrGroupRef: {}
+                            required:
+                            - cidrGroupRef
+                          - properties:
+                              cidrGroupSelector: {}
+                            required:
+                            - cidrGroupSelector
+                          properties:
+                            cidr:
+                              description: CIDR is a CIDR prefix / IP Block.
+                              format: cidr
+                              type: string
+                            cidrGroupRef:
+                              description: |-
+                                CIDRGroupRef is a reference to a CiliumCIDRGroup object.
+                                A CiliumCIDRGroup contains a list of CIDRs that the endpoint, subject to
+                                the rule, can (Ingress/Egress) or cannot (IngressDeny/EgressDeny) receive
+                                connections from.
+                              maxLength: 253
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            cidrGroupSelector:
+                              description: |-
+                                CIDRGroupSelector selects CiliumCIDRGroups by their labels,
+                                rather than by name.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        enum:
+                                        - In
+                                        - NotIn
+                                        - Exists
+                                        - DoesNotExist
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    description: MatchLabelsValue represents the value
+                                      from the MatchLabels {key,value} pair.
+                                    maxLength: 63
+                                    pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            except:
+                              description: |-
+                                ExceptCIDRs is a list of IP blocks which the endpoint subject to the rule
+                                is not allowed to initiate connections to. These CIDR prefixes should be
+                                contained within Cidr, using ExceptCIDRs together with CIDRGroupRef is not
+                                supported yet.
+                                These exceptions are only applied to the Cidr in this CIDRRule, and do not
+                                apply to any other CIDR prefixes in any other CIDRRules.
+                              items:
+                                description: |-
+                                  CIDR specifies a block of IP addresses.
+                                  Example: 192.0.2.1/32
+                                format: cidr
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      toEndpoints:
+                        description: |-
+                          ToEndpoints is a list of endpoints identified by an EndpointSelector to
+                          which the endpoints subject to the rule are allowed to communicate.
+
+                          Example:
+                          Any endpoint with the label "role=frontend" can communicate with any
+                          endpoint carrying the label "role=backend".
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      toEntities:
+                        description: |-
+                          ToEntities is a list of special entities to which the endpoint subject
+                          to the rule is allowed to initiate connections. Supported entities are
+                          `world`, `cluster`,`host`,`remote-node`,`kube-apiserver`, `init`,
+                          `health`,`unmanaged` and `all`.
+                        items:
+                          description: |-
+                            Entity specifies the class of receiver/sender endpoints that do not have
+                            individual identities.  Entities are used to describe "outside of cluster",
+                            "host", etc.
+                          enum:
+                          - all
+                          - world
+                          - cluster
+                          - host
+                          - init
+                          - ingress
+                          - unmanaged
+                          - remote-node
+                          - health
+                          - none
+                          - kube-apiserver
+                          type: string
+                        type: array
+                      toGroups:
+                        description: |-
+                          ToGroups is a directive that allows the integration with multiple outside
+                          providers. Currently, only AWS is supported, and the rule can select by
+                          multiple sub directives:
+
+                          Example:
+                          toGroups:
+                          - aws:
+                              securityGroupsIds:
+                              - 'sg-XXXXXXXXXXXXX'
+                        items:
+                          description: |-
+                            Groups structure to store all kinds of new integrations that needs a new
+                            derivative policy.
+                          properties:
+                            aws:
+                              description: AWSGroup is an structure that can be used
+                                to whitelisting information from AWS integration
+                              properties:
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                region:
+                                  type: string
+                                securityGroupsIds:
+                                  items:
+                                    type: string
+                                  type: array
+                                securityGroupsNames:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      toNodes:
+                        description: |-
+                          ToNodes is a list of nodes identified by an
+                          EndpointSelector to which endpoints subject to the rule is allowed to communicate.
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      toPorts:
+                        description: |-
+                          ToPorts is a list of destination ports identified by port number and
+                          protocol which the endpoint subject to the rule is not allowed to connect
+                          to.
+
+                          Example:
+                          Any endpoint with the label "role=frontend" is not allowed to initiate
+                          connections to destination port 8080/tcp
+                        items:
+                          description: |-
+                            PortDenyRule is a list of ports/protocol that should be used for deny
+                            policies. This structure lacks the L7Rules since it's not supported in deny
+                            policies.
+                          properties:
+                            ports:
+                              description: Ports is a list of L4 port/protocol
+                              items:
+                                description: PortProtocol specifies an L4 port with
+                                  an optional transport protocol
+                                properties:
+                                  endPort:
+                                    description: EndPort can only be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
+                                  port:
+                                    description: |-
+                                      Port can be an L4 port number, or a name in the form of "http"
+                                      or "http-8080".
+                                    pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                    type: string
+                                  protocol:
+                                    description: |-
+                                      Protocol is the L4 protocol. If omitted or empty, any protocol
+                                      matches. Accepted values: "TCP", "UDP", "SCTP", "ANY"
+
+                                      Matching on ICMP is not supported.
+
+                                      Named port specified for a container may narrow this down, but may not
+                                      contradict this.
+                                    enum:
+                                    - TCP
+                                    - UDP
+                                    - SCTP
+                                    - ANY
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                      toRequires:
+                        description: |-
+                          ToRequires is a list of additional constraints which must be met
+                          in order for the selected endpoints to be able to connect to other
+                          endpoints. These additional constraints do no by itself grant access
+                          privileges and must always be accompanied with at least one matching
+                          ToEndpoints.
+
+                          Example:
+                          Any Endpoint with the label "team=A" requires any endpoint to which it
+                          communicates to also carry the label "team=A".
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      toServices:
+                        description: |-
+                          ToServices is a list of services to which the endpoint subject
+                          to the rule is allowed to initiate connections.
+                          Currently Cilium only supports toServices for K8s services.
+                        items:
+                          description: |-
+                            Service selects policy targets that are bundled as part of a
+                            logical load-balanced service.
+
+                            Currently only Kubernetes-based Services are supported.
+                          properties:
+                            k8sService:
+                              description: K8sService selects service by name and
+                                namespace pair
+                              properties:
+                                namespace:
+                                  type: string
+                                serviceName:
+                                  type: string
+                              type: object
+                            k8sServiceSelector:
+                              description: K8sServiceSelector selects services by
+                                k8s labels and namespace
+                              properties:
+                                namespace:
+                                  type: string
+                                selector:
+                                  description: ServiceSelector is a label selector
+                                    for k8s services
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            enum:
+                                            - In
+                                            - NotIn
+                                            - Exists
+                                            - DoesNotExist
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        description: MatchLabelsValue represents the
+                                          value from the MatchLabels {key,value} pair.
+                                        maxLength: 63
+                                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - selector
+                              type: object
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+                enableDefaultDeny:
+                  description: |-
+                    EnableDefaultDeny determines whether this policy configures the
+                    subject endpoint(s) to have a default deny mode. If enabled,
+                    this causes all traffic not explicitly allowed by a network policy
+                    to be dropped.
+
+                    If not specified, the default is true for each traffic direction
+                    that has rules, and false otherwise. For example, if a policy
+                    only has Ingress or IngressDeny rules, then the default for
+                    ingress is true and egress is false.
+
+                    If multiple policies apply to an endpoint, that endpoint's default deny
+                    will be enabled if any policy requests it.
+
+                    This is useful for creating broad-based network policies that will not
+                    cause endpoints to enter default-deny mode.
+                  properties:
+                    egress:
+                      description: |-
+                        Whether or not the endpoint should have a default-deny rule applied
+                        to egress traffic.
+                      type: boolean
+                    ingress:
+                      description: |-
+                        Whether or not the endpoint should have a default-deny rule applied
+                        to ingress traffic.
+                      type: boolean
+                  type: object
+                endpointSelector:
+                  description: |-
+                    EndpointSelector selects all endpoints which should be subject to
+                    this rule. EndpointSelector and NodeSelector cannot be both empty and
+                    are mutually exclusive.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            enum:
+                            - In
+                            - NotIn
+                            - Exists
+                            - DoesNotExist
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        description: MatchLabelsValue represents the value from the
+                          MatchLabels {key,value} pair.
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                ingress:
+                  description: |-
+                    Ingress is a list of IngressRule which are enforced at ingress.
+                    If omitted or empty, this rule does not apply at ingress.
+                  items:
+                    description: |-
+                      IngressRule contains all rule types which can be applied at ingress,
+                      i.e. network traffic that originates outside of the endpoint and
+                      is entering the endpoint selected by the endpointSelector.
+
+                        - All members of this structure are optional. If omitted or empty, the
+                          member will have no effect on the rule.
+
+                        - If multiple members are set, all of them need to match in order for
+                          the rule to take effect. The exception to this rule is FromRequires field;
+                          the effects of any Requires field in any rule will apply to all other
+                          rules as well.
+
+                        - FromEndpoints, FromCIDR, FromCIDRSet and FromEntities are mutually
+                          exclusive. Only one of these members may be present within an individual
+                          rule.
+                    properties:
+                      authentication:
+                        description: Authentication is the required authentication
+                          type for the allowed traffic, if any.
+                        properties:
+                          mode:
+                            description: Mode is the required authentication mode
+                              for the allowed traffic, if any.
+                            enum:
+                            - disabled
+                            - required
+                            - test-always-fail
+                            type: string
+                        required:
+                        - mode
+                        type: object
+                      fromCIDR:
+                        description: |-
+                          FromCIDR is a list of IP blocks which the endpoint subject to the
+                          rule is allowed to receive connections from. Only connections which
+                          do *not* originate from the cluster or from the local host are subject
+                          to CIDR rules. In order to allow in-cluster connectivity, use the
+                          FromEndpoints field.  This will match on the source IP address of
+                          incoming connections. Adding  a prefix into FromCIDR or into
+                          FromCIDRSet with no ExcludeCIDRs is  equivalent.  Overlaps are
+                          allowed between FromCIDR and FromCIDRSet.
+
+                          Example:
+                          Any endpoint with the label "app=my-legacy-pet" is allowed to receive
+                          connections from 10.3.9.1
+                        items:
+                          description: |-
+                            CIDR specifies a block of IP addresses.
+                            Example: 192.0.2.1/32
+                          format: cidr
+                          type: string
+                        type: array
+                      fromCIDRSet:
+                        description: |-
+                          FromCIDRSet is a list of IP blocks which the endpoint subject to the
+                          rule is allowed to receive connections from in addition to FromEndpoints,
+                          along with a list of subnets contained within their corresponding IP block
+                          from which traffic should not be allowed.
+                          This will match on the source IP address of incoming connections. Adding
+                          a prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is
+                          equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+
+                          Example:
+                          Any endpoint with the label "app=my-legacy-pet" is allowed to receive
+                          connections from 10.0.0.0/8 except from IPs in subnet 10.96.0.0/12.
+                        items:
+                          description: |-
+                            CIDRRule is a rule that specifies a CIDR prefix to/from which outside
+                            communication  is allowed, along with an optional list of subnets within that
+                            CIDR prefix to/from which outside communication is not allowed.
+                          oneOf:
+                          - properties:
+                              cidr: {}
+                            required:
+                            - cidr
+                          - properties:
+                              cidrGroupRef: {}
+                            required:
+                            - cidrGroupRef
+                          - properties:
+                              cidrGroupSelector: {}
+                            required:
+                            - cidrGroupSelector
+                          properties:
+                            cidr:
+                              description: CIDR is a CIDR prefix / IP Block.
+                              format: cidr
+                              type: string
+                            cidrGroupRef:
+                              description: |-
+                                CIDRGroupRef is a reference to a CiliumCIDRGroup object.
+                                A CiliumCIDRGroup contains a list of CIDRs that the endpoint, subject to
+                                the rule, can (Ingress/Egress) or cannot (IngressDeny/EgressDeny) receive
+                                connections from.
+                              maxLength: 253
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            cidrGroupSelector:
+                              description: |-
+                                CIDRGroupSelector selects CiliumCIDRGroups by their labels,
+                                rather than by name.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        enum:
+                                        - In
+                                        - NotIn
+                                        - Exists
+                                        - DoesNotExist
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    description: MatchLabelsValue represents the value
+                                      from the MatchLabels {key,value} pair.
+                                    maxLength: 63
+                                    pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            except:
+                              description: |-
+                                ExceptCIDRs is a list of IP blocks which the endpoint subject to the rule
+                                is not allowed to initiate connections to. These CIDR prefixes should be
+                                contained within Cidr, using ExceptCIDRs together with CIDRGroupRef is not
+                                supported yet.
+                                These exceptions are only applied to the Cidr in this CIDRRule, and do not
+                                apply to any other CIDR prefixes in any other CIDRRules.
+                              items:
+                                description: |-
+                                  CIDR specifies a block of IP addresses.
+                                  Example: 192.0.2.1/32
+                                format: cidr
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      fromEndpoints:
+                        description: |-
+                          FromEndpoints is a list of endpoints identified by an
+                          EndpointSelector which are allowed to communicate with the endpoint
+                          subject to the rule.
+
+                          Example:
+                          Any endpoint with the label "role=backend" can be consumed by any
+                          endpoint carrying the label "role=frontend".
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      fromEntities:
+                        description: |-
+                          FromEntities is a list of special entities which the endpoint subject
+                          to the rule is allowed to receive connections from. Supported entities are
+                          `world`, `cluster` and `host`
+                        items:
+                          description: |-
+                            Entity specifies the class of receiver/sender endpoints that do not have
+                            individual identities.  Entities are used to describe "outside of cluster",
+                            "host", etc.
+                          enum:
+                          - all
+                          - world
+                          - cluster
+                          - host
+                          - init
+                          - ingress
+                          - unmanaged
+                          - remote-node
+                          - health
+                          - none
+                          - kube-apiserver
+                          type: string
+                        type: array
+                      fromGroups:
+                        description: |-
+                          FromGroups is a directive that allows the integration with multiple outside
+                          providers. Currently, only AWS is supported, and the rule can select by
+                          multiple sub directives:
+
+                          Example:
+                          FromGroups:
+                          - aws:
+                              securityGroupsIds:
+                              - 'sg-XXXXXXXXXXXXX'
+                        items:
+                          description: |-
+                            Groups structure to store all kinds of new integrations that needs a new
+                            derivative policy.
+                          properties:
+                            aws:
+                              description: AWSGroup is an structure that can be used
+                                to whitelisting information from AWS integration
+                              properties:
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                region:
+                                  type: string
+                                securityGroupsIds:
+                                  items:
+                                    type: string
+                                  type: array
+                                securityGroupsNames:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      fromNodes:
+                        description: |-
+                          FromNodes is a list of nodes identified by an
+                          EndpointSelector which are allowed to communicate with the endpoint
+                          subject to the rule.
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      fromRequires:
+                        description: |-
+                          FromRequires is a list of additional constraints which must be met
+                          in order for the selected endpoints to be reachable. These
+                          additional constraints do no by itself grant access privileges and
+                          must always be accompanied with at least one matching FromEndpoints.
+
+                          Example:
+                          Any Endpoint with the label "team=A" requires consuming endpoint
+                          to also carry the label "team=A".
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      icmps:
+                        description: |-
+                          ICMPs is a list of ICMP rule identified by type number
+                          which the endpoint subject to the rule is allowed to
+                          receive connections on.
+
+                          Example:
+                          Any endpoint with the label "app=httpd" can only accept incoming
+                          type 8 ICMP connections.
+                        items:
+                          description: ICMPRule is a list of ICMP fields.
+                          properties:
+                            fields:
+                              description: Fields is a list of ICMP fields.
+                              items:
+                                description: ICMPField is a ICMP field.
+                                properties:
+                                  family:
+                                    default: IPv4
+                                    description: |-
+                                      Family is a IP address version.
+                                      Currently, we support `IPv4` and `IPv6`.
+                                      `IPv4` is set as default.
+                                    enum:
+                                    - IPv4
+                                    - IPv6
+                                    type: string
+                                  type:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: "Type is a ICMP-type.\nIt should
+                                      be an 8bit code (0-255), or it's CamelCase name
+                                      (for example, \"EchoReply\").\nAllowed ICMP
+                                      types are:\n    Ipv4: EchoReply | DestinationUnreachable
+                                      | Redirect | Echo | EchoRequest |\n\t\t     RouterAdvertisement
+                                      | RouterSelection | TimeExceeded | ParameterProblem
+                                      |\n\t\t\t Timestamp | TimestampReply | Photuris
+                                      | ExtendedEcho Request | ExtendedEcho Reply\n
+                                      \   Ipv6: DestinationUnreachable | PacketTooBig
+                                      | TimeExceeded | ParameterProblem |\n\t\t\t
+                                      EchoRequest | EchoReply | MulticastListenerQuery|
+                                      MulticastListenerReport |\n\t\t\t MulticastListenerDone
+                                      | RouterSolicitation | RouterAdvertisement |
+                                      NeighborSolicitation |\n\t\t\t NeighborAdvertisement
+                                      | RedirectMessage | RouterRenumbering | ICMPNodeInformationQuery
+                                      |\n\t\t\t ICMPNodeInformationResponse | InverseNeighborDiscoverySolicitation
+                                      | InverseNeighborDiscoveryAdvertisement |\n\t\t\t
+                                      HomeAgentAddressDiscoveryRequest | HomeAgentAddressDiscoveryReply
+                                      | MobilePrefixSolicitation |\n\t\t\t MobilePrefixAdvertisement
+                                      | DuplicateAddressRequestCodeSuffix | DuplicateAddressConfirmationCodeSuffix
+                                      |\n\t\t\t ExtendedEchoRequest | ExtendedEchoReply"
+                                    pattern: ^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]|EchoReply|DestinationUnreachable|Redirect|Echo|RouterAdvertisement|RouterSelection|TimeExceeded|ParameterProblem|Timestamp|TimestampReply|Photuris|ExtendedEchoRequest|ExtendedEcho
+                                      Reply|PacketTooBig|ParameterProblem|EchoRequest|MulticastListenerQuery|MulticastListenerReport|MulticastListenerDone|RouterSolicitation|RouterAdvertisement|NeighborSolicitation|NeighborAdvertisement|RedirectMessage|RouterRenumbering|ICMPNodeInformationQuery|ICMPNodeInformationResponse|InverseNeighborDiscoverySolicitation|InverseNeighborDiscoveryAdvertisement|HomeAgentAddressDiscoveryRequest|HomeAgentAddressDiscoveryReply|MobilePrefixSolicitation|MobilePrefixAdvertisement|DuplicateAddressRequestCodeSuffix|DuplicateAddressConfirmationCodeSuffix)$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - type
+                                type: object
+                              maxItems: 40
+                              type: array
+                          type: object
+                        type: array
+                      toPorts:
+                        description: |-
+                          ToPorts is a list of destination ports identified by port number and
+                          protocol which the endpoint subject to the rule is allowed to
+                          receive connections on.
+
+                          Example:
+                          Any endpoint with the label "app=httpd" can only accept incoming
+                          connections on port 80/tcp.
+                        items:
+                          description: |-
+                            PortRule is a list of ports/protocol combinations with optional Layer 7
+                            rules which must be met.
+                          properties:
+                            listener:
+                              description: |-
+                                listener specifies the name of a custom Envoy listener to which this traffic should be
+                                redirected to.
+                              properties:
+                                envoyConfig:
+                                  description: |-
+                                    EnvoyConfig is a reference to the CEC or CCEC resource in which
+                                    the listener is defined.
+                                  properties:
+                                    kind:
+                                      description: |-
+                                        Kind is the resource type being referred to. Defaults to CiliumEnvoyConfig or
+                                        CiliumClusterwideEnvoyConfig for CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy,
+                                        respectively. The only case this is currently explicitly needed is when referring to a
+                                        CiliumClusterwideEnvoyConfig from CiliumNetworkPolicy, as using a namespaced listener
+                                        from a cluster scoped policy is not allowed.
+                                      enum:
+                                      - CiliumEnvoyConfig
+                                      - CiliumClusterwideEnvoyConfig
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name is the resource name of the CiliumEnvoyConfig or CiliumClusterwideEnvoyConfig where
+                                        the listener is defined in.
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                name:
+                                  description: Name is the name of the listener.
+                                  minLength: 1
+                                  type: string
+                                priority:
+                                  description: |-
+                                    Priority for this Listener that is used when multiple rules would apply different
+                                    listeners to a policy map entry. Behavior of this is implementation dependent.
+                                  maximum: 100
+                                  minimum: 1
+                                  type: integer
+                              required:
+                              - envoyConfig
+                              - name
+                              type: object
+                            originatingTLS:
+                              description: |-
+                                OriginatingTLS is the TLS context for the connections originated by
+                                the L7 proxy.  For egress policy this specifies the client-side TLS
+                                parameters for the upstream connection originating from the L7 proxy
+                                to the remote destination. For ingress policy this specifies the
+                                client-side TLS parameters for the connection from the L7 proxy to
+                                the local endpoint.
+                              properties:
+                                certificate:
+                                  description: |-
+                                    Certificate is the file name or k8s secret item name for the certificate
+                                    chain. If omitted, 'tls.crt' is assumed, if it exists. If given, the
+                                    item must exist.
+                                  type: string
+                                privateKey:
+                                  description: |-
+                                    PrivateKey is the file name or k8s secret item name for the private key
+                                    matching the certificate chain. If omitted, 'tls.key' is assumed, if it
+                                    exists. If given, the item must exist.
+                                  type: string
+                                secret:
+                                  description: |-
+                                    Secret is the secret that contains the certificates and private key for
+                                    the TLS context.
+                                    By default, Cilium will search in this secret for the following items:
+                                     - 'ca.crt'  - Which represents the trusted CA to verify remote source.
+                                     - 'tls.crt' - Which represents the public key certificate.
+                                     - 'tls.key' - Which represents the private key matching the public key
+                                                   certificate.
+                                  properties:
+                                    name:
+                                      description: Name is the name of the secret.
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace in which the secret exists. Context of use
+                                        determines the default value if left out (e.g., "default").
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                trustedCA:
+                                  description: |-
+                                    TrustedCA is the file name or k8s secret item name for the trusted CA.
+                                    If omitted, 'ca.crt' is assumed, if it exists. If given, the item must
+                                    exist.
+                                  type: string
+                              required:
+                              - secret
+                              type: object
+                            ports:
+                              description: Ports is a list of L4 port/protocol
+                              items:
+                                description: PortProtocol specifies an L4 port with
+                                  an optional transport protocol
+                                properties:
+                                  endPort:
+                                    description: EndPort can only be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
+                                  port:
+                                    description: |-
+                                      Port can be an L4 port number, or a name in the form of "http"
+                                      or "http-8080".
+                                    pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                    type: string
+                                  protocol:
+                                    description: |-
+                                      Protocol is the L4 protocol. If omitted or empty, any protocol
+                                      matches. Accepted values: "TCP", "UDP", "SCTP", "ANY"
+
+                                      Matching on ICMP is not supported.
+
+                                      Named port specified for a container may narrow this down, but may not
+                                      contradict this.
+                                    enum:
+                                    - TCP
+                                    - UDP
+                                    - SCTP
+                                    - ANY
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              maxItems: 40
+                              type: array
+                            rules:
+                              description: |-
+                                Rules is a list of additional port level rules which must be met in
+                                order for the PortRule to allow the traffic. If omitted or empty,
+                                no layer 7 rules are enforced.
+                              oneOf:
+                              - properties:
+                                  http: {}
+                                required:
+                                - http
+                              - properties:
+                                  kafka: {}
+                                required:
+                                - kafka
+                              - properties:
+                                  dns: {}
+                                required:
+                                - dns
+                              - properties:
+                                  l7proto: {}
+                                required:
+                                - l7proto
+                              properties:
+                                dns:
+                                  description: DNS-specific rules.
+                                  items:
+                                    description: PortRuleDNS is a list of allowed
+                                      DNS lookups.
+                                    oneOf:
+                                    - properties:
+                                        matchName: {}
+                                      required:
+                                      - matchName
+                                    - properties:
+                                        matchPattern: {}
+                                      required:
+                                      - matchPattern
+                                    properties:
+                                      matchName:
+                                        description: |-
+                                          MatchName matches literal DNS names. A trailing "." is automatically added
+                                          when missing.
+                                        maxLength: 255
+                                        pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                                        type: string
+                                      matchPattern:
+                                        description: |-
+                                          MatchPattern allows using wildcards to match DNS names. All wildcards are
+                                          case insensitive. The wildcards are:
+                                          - "*" matches 0 or more DNS valid characters, and may occur anywhere in
+                                          the pattern. As a special case a "*" as the leftmost character, without a
+                                          following "." matches all subdomains as well as the name to the right.
+                                          A trailing "." is automatically added when missing.
+
+                                          Examples:
+                                          `*.cilium.io` matches subomains of cilium at that level
+                                            www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
+                                          `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                            except those containing "." separator, subcilium.io and sub-cilium.io match,
+                                            www.cilium.io and blog.cilium.io does not
+                                          sub*.cilium.io matches subdomains of cilium where the subdomain component
+                                          begins with "sub"
+                                            sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                            blog.cilium.io, cilium.io and google.com do not
+                                        maxLength: 255
+                                        pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                                        type: string
+                                    type: object
+                                  type: array
+                                http:
+                                  description: HTTP specific rules.
+                                  items:
+                                    description: |-
+                                      PortRuleHTTP is a list of HTTP protocol constraints. All fields are
+                                      optional, if all fields are empty or missing, the rule does not have any
+                                      effect.
+
+                                      All fields of this type are extended POSIX regex as defined by IEEE Std
+                                      1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax)
+                                      matched against the path of an incoming request. Currently it can contain
+                                      characters disallowed from the conventional "path" part of a URL as defined
+                                      by RFC 3986.
+                                    properties:
+                                      headerMatches:
+                                        description: |-
+                                          HeaderMatches is a list of HTTP headers which must be
+                                          present and match against the given values. Mismatch field can be used
+                                          to specify what to do when there is no match.
+                                        items:
+                                          description: |-
+                                            HeaderMatch extends the HeaderValue for matching requirement of a
+                                            named header field against an immediate string, a secret value, or
+                                            a regex.  If none of the optional fields is present, then the
+                                            header value is not matched, only presence of the header is enough.
+                                          properties:
+                                            mismatch:
+                                              description: |-
+                                                Mismatch identifies what to do in case there is no match. The default is
+                                                to drop the request. Otherwise the overall rule is still considered as
+                                                matching, but the mismatches are logged in the access log.
+                                              enum:
+                                              - LOG
+                                              - ADD
+                                              - DELETE
+                                              - REPLACE
+                                              type: string
+                                            name:
+                                              description: Name identifies the header.
+                                              minLength: 1
+                                              type: string
+                                            secret:
+                                              description: |-
+                                                Secret refers to a secret that contains the value to be matched against.
+                                                The secret must only contain one entry. If the referred secret does not
+                                                exist, and there is no "Value" specified, the match will fail.
+                                              properties:
+                                                name:
+                                                  description: Name is the name of
+                                                    the secret.
+                                                  type: string
+                                                namespace:
+                                                  description: |-
+                                                    Namespace is the namespace in which the secret exists. Context of use
+                                                    determines the default value if left out (e.g., "default").
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            value:
+                                              description: |-
+                                                Value matches the exact value of the header. Can be specified either
+                                                alone or together with "Secret"; will be used as the header value if the
+                                                secret can not be found in the latter case.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      headers:
+                                        description: |-
+                                          Headers is a list of HTTP headers which must be present in the
+                                          request. If omitted or empty, requests are allowed regardless of
+                                          headers present.
+                                        items:
+                                          type: string
+                                        type: array
+                                      host:
+                                        description: |-
+                                          Host is an extended POSIX regex matched against the host header of a
+                                          request. Examples:
+
+                                          - foo.bar.com will match the host fooXbar.com or foo-bar.com
+                                          - foo\.bar\.com will only match the host foo.bar.com
+
+                                          If omitted or empty, the value of the host header is ignored.
+                                        format: idn-hostname
+                                        type: string
+                                      method:
+                                        description: |-
+                                          Method is an extended POSIX regex matched against the method of a
+                                          request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                                          If omitted or empty, all methods are allowed.
+                                        type: string
+                                      path:
+                                        description: |-
+                                          Path is an extended POSIX regex matched against the path of a
+                                          request. Currently it can contain characters disallowed from the
+                                          conventional "path" part of a URL as defined by RFC 3986.
+
+                                          If omitted or empty, all paths are all allowed.
+                                        type: string
+                                    type: object
+                                  type: array
+                                kafka:
+                                  description: Kafka-specific rules.
+                                  items:
+                                    description: |-
+                                      PortRule is a list of Kafka protocol constraints. All fields are
+                                      optional, if all fields are empty or missing, the rule will match all
+                                      Kafka messages.
+                                    properties:
+                                      apiKey:
+                                        description: |-
+                                          APIKey is a case-insensitive string matched against the key of a
+                                          request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al
+                                          Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                                          If omitted or empty, and if Role is not specified, then all keys are allowed.
+                                        type: string
+                                      apiVersion:
+                                        description: |-
+                                          APIVersion is the version matched against the api version of the
+                                          Kafka message. If set, it has to be a string representing a positive
+                                          integer.
+
+                                          If omitted or empty, all versions are allowed.
+                                        type: string
+                                      clientID:
+                                        description: |-
+                                          ClientID is the client identifier as provided in the request.
+
+                                          From Kafka protocol documentation:
+                                          This is a user supplied identifier for the client application. The
+                                          user can use any identifier they like and it will be used when
+                                          logging errors, monitoring aggregates, etc. For example, one might
+                                          want to monitor not just the requests per second overall, but the
+                                          number coming from each client application (each of which could
+                                          reside on multiple servers). This id acts as a logical grouping
+                                          across all requests from a particular client.
+
+                                          If omitted or empty, all client identifiers are allowed.
+                                        type: string
+                                      role:
+                                        description: |-
+                                          Role is a case-insensitive string and describes a group of API keys
+                                          necessary to perform certain higher-level Kafka operations such as "produce"
+                                          or "consume". A Role automatically expands into all APIKeys required
+                                          to perform the specified higher-level operation.
+
+                                          The following values are supported:
+                                           - "produce": Allow producing to the topics specified in the rule
+                                           - "consume": Allow consuming from the topics specified in the rule
+
+                                          This field is incompatible with the APIKey field, i.e APIKey and Role
+                                          cannot both be specified in the same rule.
+
+                                          If omitted or empty, and if APIKey is not specified, then all keys are
+                                          allowed.
+                                        enum:
+                                        - produce
+                                        - consume
+                                        type: string
+                                      topic:
+                                        description: |-
+                                          Topic is the topic name contained in the message. If a Kafka request
+                                          contains multiple topics, then all topics must be allowed or the
+                                          message will be rejected.
+
+                                          This constraint is ignored if the matched request message type
+                                          doesn't contain any topic. Maximum size of Topic can be 249
+                                          characters as per recent Kafka spec and allowed characters are
+                                          a-z, A-Z, 0-9, -, . and _.
+
+                                          Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10
+                                          version the length was changed from 255 to 249. For compatibility
+                                          reasons we are using 255.
+
+                                          If omitted or empty, all topics are allowed.
+                                        maxLength: 255
+                                        type: string
+                                    type: object
+                                  type: array
+                                l7:
+                                  description: Key-value pair rules.
+                                  items:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      PortRuleL7 is a list of key-value pairs interpreted by a L7 protocol as
+                                      protocol constraints. All fields are optional, if all fields are empty or
+                                      missing, the rule does not have any effect.
+                                    type: object
+                                  type: array
+                                l7proto:
+                                  description: Name of the L7 protocol for which the
+                                    Key-value pair rules apply.
+                                  type: string
+                              type: object
+                            serverNames:
+                              description: |-
+                                ServerNames is a list of allowed TLS SNI values. If not empty, then
+                                TLS must be present and one of the provided SNIs must be indicated in the
+                                TLS handshake.
+                              items:
+                                type: string
+                              type: array
+                            terminatingTLS:
+                              description: |-
+                                TerminatingTLS is the TLS context for the connection terminated by
+                                the L7 proxy.  For egress policy this specifies the server-side TLS
+                                parameters to be applied on the connections originated from the local
+                                endpoint and terminated by the L7 proxy. For ingress policy this specifies
+                                the server-side TLS parameters to be applied on the connections
+                                originated from a remote source and terminated by the L7 proxy.
+                              properties:
+                                certificate:
+                                  description: |-
+                                    Certificate is the file name or k8s secret item name for the certificate
+                                    chain. If omitted, 'tls.crt' is assumed, if it exists. If given, the
+                                    item must exist.
+                                  type: string
+                                privateKey:
+                                  description: |-
+                                    PrivateKey is the file name or k8s secret item name for the private key
+                                    matching the certificate chain. If omitted, 'tls.key' is assumed, if it
+                                    exists. If given, the item must exist.
+                                  type: string
+                                secret:
+                                  description: |-
+                                    Secret is the secret that contains the certificates and private key for
+                                    the TLS context.
+                                    By default, Cilium will search in this secret for the following items:
+                                     - 'ca.crt'  - Which represents the trusted CA to verify remote source.
+                                     - 'tls.crt' - Which represents the public key certificate.
+                                     - 'tls.key' - Which represents the private key matching the public key
+                                                   certificate.
+                                  properties:
+                                    name:
+                                      description: Name is the name of the secret.
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace in which the secret exists. Context of use
+                                        determines the default value if left out (e.g., "default").
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                trustedCA:
+                                  description: |-
+                                    TrustedCA is the file name or k8s secret item name for the trusted CA.
+                                    If omitted, 'ca.crt' is assumed, if it exists. If given, the item must
+                                    exist.
+                                  type: string
+                              required:
+                              - secret
+                              type: object
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+                ingressDeny:
+                  description: |-
+                    IngressDeny is a list of IngressDenyRule which are enforced at ingress.
+                    Any rule inserted here will be denied regardless of the allowed ingress
+                    rules in the 'ingress' field.
+                    If omitted or empty, this rule does not apply at ingress.
+                  items:
+                    description: |-
+                      IngressDenyRule contains all rule types which can be applied at ingress,
+                      i.e. network traffic that originates outside of the endpoint and
+                      is entering the endpoint selected by the endpointSelector.
+
+                        - All members of this structure are optional. If omitted or empty, the
+                          member will have no effect on the rule.
+
+                        - If multiple members are set, all of them need to match in order for
+                          the rule to take effect. The exception to this rule is FromRequires field;
+                          the effects of any Requires field in any rule will apply to all other
+                          rules as well.
+
+                        - FromEndpoints, FromCIDR, FromCIDRSet, FromGroups and FromEntities are mutually
+                          exclusive. Only one of these members may be present within an individual
+                          rule.
+                    properties:
+                      fromCIDR:
+                        description: |-
+                          FromCIDR is a list of IP blocks which the endpoint subject to the
+                          rule is allowed to receive connections from. Only connections which
+                          do *not* originate from the cluster or from the local host are subject
+                          to CIDR rules. In order to allow in-cluster connectivity, use the
+                          FromEndpoints field.  This will match on the source IP address of
+                          incoming connections. Adding  a prefix into FromCIDR or into
+                          FromCIDRSet with no ExcludeCIDRs is  equivalent.  Overlaps are
+                          allowed between FromCIDR and FromCIDRSet.
+
+                          Example:
+                          Any endpoint with the label "app=my-legacy-pet" is allowed to receive
+                          connections from 10.3.9.1
+                        items:
+                          description: |-
+                            CIDR specifies a block of IP addresses.
+                            Example: 192.0.2.1/32
+                          format: cidr
+                          type: string
+                        type: array
+                      fromCIDRSet:
+                        description: |-
+                          FromCIDRSet is a list of IP blocks which the endpoint subject to the
+                          rule is allowed to receive connections from in addition to FromEndpoints,
+                          along with a list of subnets contained within their corresponding IP block
+                          from which traffic should not be allowed.
+                          This will match on the source IP address of incoming connections. Adding
+                          a prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is
+                          equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+
+                          Example:
+                          Any endpoint with the label "app=my-legacy-pet" is allowed to receive
+                          connections from 10.0.0.0/8 except from IPs in subnet 10.96.0.0/12.
+                        items:
+                          description: |-
+                            CIDRRule is a rule that specifies a CIDR prefix to/from which outside
+                            communication  is allowed, along with an optional list of subnets within that
+                            CIDR prefix to/from which outside communication is not allowed.
+                          oneOf:
+                          - properties:
+                              cidr: {}
+                            required:
+                            - cidr
+                          - properties:
+                              cidrGroupRef: {}
+                            required:
+                            - cidrGroupRef
+                          - properties:
+                              cidrGroupSelector: {}
+                            required:
+                            - cidrGroupSelector
+                          properties:
+                            cidr:
+                              description: CIDR is a CIDR prefix / IP Block.
+                              format: cidr
+                              type: string
+                            cidrGroupRef:
+                              description: |-
+                                CIDRGroupRef is a reference to a CiliumCIDRGroup object.
+                                A CiliumCIDRGroup contains a list of CIDRs that the endpoint, subject to
+                                the rule, can (Ingress/Egress) or cannot (IngressDeny/EgressDeny) receive
+                                connections from.
+                              maxLength: 253
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            cidrGroupSelector:
+                              description: |-
+                                CIDRGroupSelector selects CiliumCIDRGroups by their labels,
+                                rather than by name.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        enum:
+                                        - In
+                                        - NotIn
+                                        - Exists
+                                        - DoesNotExist
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    description: MatchLabelsValue represents the value
+                                      from the MatchLabels {key,value} pair.
+                                    maxLength: 63
+                                    pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            except:
+                              description: |-
+                                ExceptCIDRs is a list of IP blocks which the endpoint subject to the rule
+                                is not allowed to initiate connections to. These CIDR prefixes should be
+                                contained within Cidr, using ExceptCIDRs together with CIDRGroupRef is not
+                                supported yet.
+                                These exceptions are only applied to the Cidr in this CIDRRule, and do not
+                                apply to any other CIDR prefixes in any other CIDRRules.
+                              items:
+                                description: |-
+                                  CIDR specifies a block of IP addresses.
+                                  Example: 192.0.2.1/32
+                                format: cidr
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      fromEndpoints:
+                        description: |-
+                          FromEndpoints is a list of endpoints identified by an
+                          EndpointSelector which are allowed to communicate with the endpoint
+                          subject to the rule.
+
+                          Example:
+                          Any endpoint with the label "role=backend" can be consumed by any
+                          endpoint carrying the label "role=frontend".
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      fromEntities:
+                        description: |-
+                          FromEntities is a list of special entities which the endpoint subject
+                          to the rule is allowed to receive connections from. Supported entities are
+                          `world`, `cluster` and `host`
+                        items:
+                          description: |-
+                            Entity specifies the class of receiver/sender endpoints that do not have
+                            individual identities.  Entities are used to describe "outside of cluster",
+                            "host", etc.
+                          enum:
+                          - all
+                          - world
+                          - cluster
+                          - host
+                          - init
+                          - ingress
+                          - unmanaged
+                          - remote-node
+                          - health
+                          - none
+                          - kube-apiserver
+                          type: string
+                        type: array
+                      fromGroups:
+                        description: |-
+                          FromGroups is a directive that allows the integration with multiple outside
+                          providers. Currently, only AWS is supported, and the rule can select by
+                          multiple sub directives:
+
+                          Example:
+                          FromGroups:
+                          - aws:
+                              securityGroupsIds:
+                              - 'sg-XXXXXXXXXXXXX'
+                        items:
+                          description: |-
+                            Groups structure to store all kinds of new integrations that needs a new
+                            derivative policy.
+                          properties:
+                            aws:
+                              description: AWSGroup is an structure that can be used
+                                to whitelisting information from AWS integration
+                              properties:
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                region:
+                                  type: string
+                                securityGroupsIds:
+                                  items:
+                                    type: string
+                                  type: array
+                                securityGroupsNames:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      fromNodes:
+                        description: |-
+                          FromNodes is a list of nodes identified by an
+                          EndpointSelector which are allowed to communicate with the endpoint
+                          subject to the rule.
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      fromRequires:
+                        description: |-
+                          FromRequires is a list of additional constraints which must be met
+                          in order for the selected endpoints to be reachable. These
+                          additional constraints do no by itself grant access privileges and
+                          must always be accompanied with at least one matching FromEndpoints.
+
+                          Example:
+                          Any Endpoint with the label "team=A" requires consuming endpoint
+                          to also carry the label "team=A".
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      icmps:
+                        description: |-
+                          ICMPs is a list of ICMP rule identified by type number
+                          which the endpoint subject to the rule is not allowed to
+                          receive connections on.
+
+                          Example:
+                          Any endpoint with the label "app=httpd" can not accept incoming
+                          type 8 ICMP connections.
+                        items:
+                          description: ICMPRule is a list of ICMP fields.
+                          properties:
+                            fields:
+                              description: Fields is a list of ICMP fields.
+                              items:
+                                description: ICMPField is a ICMP field.
+                                properties:
+                                  family:
+                                    default: IPv4
+                                    description: |-
+                                      Family is a IP address version.
+                                      Currently, we support `IPv4` and `IPv6`.
+                                      `IPv4` is set as default.
+                                    enum:
+                                    - IPv4
+                                    - IPv6
+                                    type: string
+                                  type:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: "Type is a ICMP-type.\nIt should
+                                      be an 8bit code (0-255), or it's CamelCase name
+                                      (for example, \"EchoReply\").\nAllowed ICMP
+                                      types are:\n    Ipv4: EchoReply | DestinationUnreachable
+                                      | Redirect | Echo | EchoRequest |\n\t\t     RouterAdvertisement
+                                      | RouterSelection | TimeExceeded | ParameterProblem
+                                      |\n\t\t\t Timestamp | TimestampReply | Photuris
+                                      | ExtendedEcho Request | ExtendedEcho Reply\n
+                                      \   Ipv6: DestinationUnreachable | PacketTooBig
+                                      | TimeExceeded | ParameterProblem |\n\t\t\t
+                                      EchoRequest | EchoReply | MulticastListenerQuery|
+                                      MulticastListenerReport |\n\t\t\t MulticastListenerDone
+                                      | RouterSolicitation | RouterAdvertisement |
+                                      NeighborSolicitation |\n\t\t\t NeighborAdvertisement
+                                      | RedirectMessage | RouterRenumbering | ICMPNodeInformationQuery
+                                      |\n\t\t\t ICMPNodeInformationResponse | InverseNeighborDiscoverySolicitation
+                                      | InverseNeighborDiscoveryAdvertisement |\n\t\t\t
+                                      HomeAgentAddressDiscoveryRequest | HomeAgentAddressDiscoveryReply
+                                      | MobilePrefixSolicitation |\n\t\t\t MobilePrefixAdvertisement
+                                      | DuplicateAddressRequestCodeSuffix | DuplicateAddressConfirmationCodeSuffix
+                                      |\n\t\t\t ExtendedEchoRequest | ExtendedEchoReply"
+                                    pattern: ^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]|EchoReply|DestinationUnreachable|Redirect|Echo|RouterAdvertisement|RouterSelection|TimeExceeded|ParameterProblem|Timestamp|TimestampReply|Photuris|ExtendedEchoRequest|ExtendedEcho
+                                      Reply|PacketTooBig|ParameterProblem|EchoRequest|MulticastListenerQuery|MulticastListenerReport|MulticastListenerDone|RouterSolicitation|RouterAdvertisement|NeighborSolicitation|NeighborAdvertisement|RedirectMessage|RouterRenumbering|ICMPNodeInformationQuery|ICMPNodeInformationResponse|InverseNeighborDiscoverySolicitation|InverseNeighborDiscoveryAdvertisement|HomeAgentAddressDiscoveryRequest|HomeAgentAddressDiscoveryReply|MobilePrefixSolicitation|MobilePrefixAdvertisement|DuplicateAddressRequestCodeSuffix|DuplicateAddressConfirmationCodeSuffix)$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - type
+                                type: object
+                              maxItems: 40
+                              type: array
+                          type: object
+                        type: array
+                      toPorts:
+                        description: |-
+                          ToPorts is a list of destination ports identified by port number and
+                          protocol which the endpoint subject to the rule is not allowed to
+                          receive connections on.
+
+                          Example:
+                          Any endpoint with the label "app=httpd" can not accept incoming
+                          connections on port 80/tcp.
+                        items:
+                          description: |-
+                            PortDenyRule is a list of ports/protocol that should be used for deny
+                            policies. This structure lacks the L7Rules since it's not supported in deny
+                            policies.
+                          properties:
+                            ports:
+                              description: Ports is a list of L4 port/protocol
+                              items:
+                                description: PortProtocol specifies an L4 port with
+                                  an optional transport protocol
+                                properties:
+                                  endPort:
+                                    description: EndPort can only be an L4 port number.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 0
+                                    type: integer
+                                  port:
+                                    description: |-
+                                      Port can be an L4 port number, or a name in the form of "http"
+                                      or "http-8080".
+                                    pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                    type: string
+                                  protocol:
+                                    description: |-
+                                      Protocol is the L4 protocol. If omitted or empty, any protocol
+                                      matches. Accepted values: "TCP", "UDP", "SCTP", "ANY"
+
+                                      Matching on ICMP is not supported.
+
+                                      Named port specified for a container may narrow this down, but may not
+                                      contradict this.
+                                    enum:
+                                    - TCP
+                                    - UDP
+                                    - SCTP
+                                    - ANY
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+                labels:
+                  description: |-
+                    Labels is a list of optional strings which can be used to
+                    re-identify the rule or to store metadata. It is possible to lookup
+                    or delete strings based on labels. Labels are not required to be
+                    unique, multiple rules can have overlapping or identical labels.
+                  items:
+                    description: Label is the Cilium's representation of a container
+                      label.
+                    properties:
+                      key:
+                        type: string
+                      source:
+                        description: 'Source can be one of the above values (e.g.:
+                          LabelSourceContainer).'
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - key
+                    type: object
+                  type: array
+                nodeSelector:
+                  description: |-
+                    NodeSelector selects all nodes which should be subject to this rule.
+                    EndpointSelector and NodeSelector cannot be both empty and are mutually
+                    exclusive. Can only be used in CiliumClusterwideNetworkPolicies.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            enum:
+                            - In
+                            - NotIn
+                            - Exists
+                            - DoesNotExist
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        description: MatchLabelsValue represents the value from the
+                          MatchLabels {key,value} pair.
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+              type: object
+            type: array
+          status:
+            description: |-
+              Status is the status of the Cilium policy rule.
+
+              The reason this field exists in this structure is due a bug in the k8s
+              code-generator that doesn't create a `UpdateStatus` method because the
+              field does not exist in the structure.
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time the condition transitioned from one
+                        status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: The status of the condition, one of True, False,
+                        or Unknown
+                      type: string
+                    type:
+                      description: The type of the policy condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              derivativePolicies:
+                additionalProperties:
+                  description: |-
+                    CiliumNetworkPolicyNodeStatus is the status of a Cilium policy rule for a
+                    specific node.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Annotations corresponds to the Annotations in the ObjectMeta of the CNP
+                        that have been realized on the node for CNP. That is, if a CNP has been
+                        imported and has been assigned annotation X=Y by the user,
+                        Annotations in CiliumNetworkPolicyNodeStatus will be X=Y once the
+                        CNP that was imported corresponding to Annotation X=Y has been realized on
+                        the node.
+                      type: object
+                    enforcing:
+                      description: |-
+                        Enforcing is set to true once all endpoints present at the time the
+                        policy has been imported are enforcing this policy.
+                      type: boolean
+                    error:
+                      description: |-
+                        Error describes any error that occurred when parsing or importing the
+                        policy, or realizing the policy for the endpoints to which it applies
+                        on the node.
+                      type: string
+                    lastUpdated:
+                      description: LastUpdated contains the last time this status
+                        was updated
+                      format: date-time
+                      type: string
+                    localPolicyRevision:
+                      description: |-
+                        Revision is the policy revision of the repository which first implemented
+                        this policy.
+                      format: int64
+                      type: integer
+                    ok:
+                      description: |-
+                        OK is true when the policy has been parsed and imported successfully
+                        into the in-memory policy repository on the node.
+                      type: boolean
+                  type: object
+                description: |-
+                  DerivativePolicies is the status of all policies derived from the Cilium
+                  policy
+                type: object
+            type: object
+        required:
+        - metadata
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/internal/schemas/generator/testdata/widget_scale_subresource.yaml
+++ b/internal/schemas/generator/testdata/widget_scale_subresource.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              replicas:
+                type: integer
+              image:
+                type: string
+          status:
+            type: object
+            properties:
+              replicas:
+                type: integer
+              selector:
+                type: string
+    subresources:
+      status: {}
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+        labelSelectorPath: .status.selector


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

Ports three Go schema generator fixes from upbound/up#1612 (where they were found and fixed after portions of up were upstreamed here)

1. **Duplicate typename for validation-only `anyOf`/`oneOf`** (fixes #131). CRDs that use both `anyOf` and `oneOf` purely for validation (e.g. Cilium ≥ 1.17's "exactly one of `endpointSelector`/`nodeSelector`" plus the ingress/egress `anyOf`) failed with: `duplicate typename 'IoCiliumV2CiliumClusterwideNetworkPolicySpec0' detected`. Kubernetes structural schemas only allow `required` constraints and empty property schemas inside these junctors, but oapi-codegen generates a union member type `<Name><index>` per variant, so `anyOf` and `oneOf` on the same schema both produce `<Name>0`. A new `goRemoveValidationOnlyCombinators` mutator strips combinators that carry no structural type information; typed ones (e.g. `x-kubernetes-int-or-string` `anyOf`) are preserved.

2. **`resource.k8s.io` (DRA, GA in k8s 1.34) clobbered the shared Quantity package.** The group reverses to `io/k8s/resource/v1`, the same path as the shared apimachinery `Quantity` package. With a k8s dependency ≥ 1.34 the DRA models overwrote it, producing a package that imported itself and an import cycle `core/v1 → resource/v1 → core/v1`. DRA models now live at `io/k8s/api/resource/<version>` (mirroring `k8s.io/api/resource`); the shared package keeps its historical path.

3. **Empty `autoscaling/v1` GVK group clobbered the shared Scale package.** `Scale` carries a GVK extension, so it formed a GVK group whose schemas are all removed by `goRemoveK8s`, generating a file over the shared autoscaling package that instead held a copy of every other schema in the spec, registering e.g. `TokenRequest` under the `autoscaling` group. GVK groups fully covered by the shared k8s packages are now skipped, and thecompile-gate consumer now asserts `Scale` is registered under `autoscaling/v1` (and `TokenRequest` under `authentication.k8s.io`).

One deliberate divergence from the up PR: its CRD-flow test expects a shared autoscaling package for CRDs with a scale subresource. This repo instead drops the scale subresource before building the OpenAPI document (809565b, #117), so
the ported test asserts the opposite, the resource's own model is generated and no autoscaling package leaks into the CRD flow.

### How has this code been tested

- New testdata fixtures: Cilium v1.17.4 `CiliumClusterwideNetworkPolicy` CRD (validation-only combinators), k8s v1.35 `apis__resource.k8s.io__v1` OpenAPI spec (DRA collision), and a minimal CRD with a scale subresource.
- New tests: `TestGenerateFromCRDGoValidationOnlyCombinators`, `TestGenerateFromCRDGoScaleSubresource`, `TestGenerateFromOpenAPIGoSharedK8sPackages`; both existing generation tests now run an AST check for duplicate and self-referential type declarations on every generated file.
- `go test ./internal/schemas/...`, `go test -tags compilegate ./internal/schemas/generator/...` (materializes the generated models module and builds it with the Go toolchain), and `golangci-lint run` all pass.


<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #131

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Linked a PR or a [docs tracking issue] to [document this change].
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
