### PR TITLE
fix(ci): clean /homeless-shelter before Renovate's Nix commands

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -29,7 +29,8 @@ build-users-group =
 # One build at a time, so no build starts before we can clean up /homeless-shelter.
 max-jobs = 1
 
-# Removes /homeless-shelter after each build (see the hook script above).
+# Removes /homeless-shelter after each successful build. The crossplane-nix launcher covers any
+# failed builds this misses.
 post-build-hook = /usr/local/bin/nix-clean-homeless-shelter
 
 # Use the Crossplane Cachix cache to download pre-built binaries from CI.
@@ -43,6 +44,8 @@ EOF
 # and the config it reads.
 cat >/usr/local/bin/crossplane-nix <<'EOF'
 #!/bin/bash
+# ensure any leftover /homeless-shelter from a failed build is cleaned up before we start
+/usr/local/bin/nix-clean-homeless-shelter
 exec env NIX_CONF_DIR=/etc/nix /usr/bin/nix "$@"
 EOF
 chmod +x /usr/local/bin/crossplane-nix


### PR DESCRIPTION
### Description of your changes

This PR ports https://github.com/crossplane/crossplane-runtime/pull/1118 from crossplane-runtime to this `crossplane/cli` repo as well:

* https://github.com/crossplane/crossplane-runtime/pull/1118 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
