### PR TITLE
fix(test): take the registry keychain from the caller, not the host

### DIFF
--- a/cmd/crossplane/validate/image.go
+++ b/cmd/crossplane/validate/image.go
@@ -168,10 +168,12 @@ func convertToSemver(tags []string) []*semver.Version {
 }
 
 // findImageTagForVersionConstraint fetches the latest tag for an image with a version constraint.
+// Callers may pass crane options; tests use this to supply an anonymous
+// keychain so the lookup does not consult the host's docker config.
 // image should be a validated image name with the format: <registry>/<image>:<tag>.
 // where <tag> can be a version constraint.
 // if <tag> is already an exact version, the same image string is returned back.
-func findImageTagForVersionConstraint(image string) (string, error) {
+func findImageTagForVersionConstraint(image string, opts ...crane.Option) (string, error) {
 	imageBase, imageTag := separateImageTag(image)
 
 	// Check if the tag is a constraint or already a valid semantic version
@@ -194,7 +196,7 @@ func findImageTagForVersionConstraint(image string) (string, error) {
 	}
 
 	// Fetch all image tags
-	tags, err := crane.ListTags(imageBase)
+	tags, err := crane.ListTags(imageBase, opts...)
 	if err != nil {
 		return "", errors.Wrapf(err, "cannot fetch tags for the image %s", imageBase)
 	}

--- a/cmd/crossplane/validate/image_test.go
+++ b/cmd/crossplane/validate/image_test.go
@@ -21,8 +21,33 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
 )
+
+// anonymousKeychain returns authn.Anonymous for every request, and records that
+// it was asked. The default keychain would consult the host's docker config: if
+// that sets a credsStore, resolving credentials shells out to
+// docker-credential-<store>, which is not on PATH under `nix run .#test`
+// (nix/apps.nix sets inheritPath = false), so the tag lookup fails on a
+// developer machine while passing in CI. internal/project/push_test.go carries
+// the same helper for the push path.
+//
+// The used flag is what keeps this honest: if the option stops being threaded
+// through to crane, this keychain is never consulted and the test fails on any
+// host, with or without a docker config.
+type anonymousKeychain struct {
+	used atomic.Bool
+}
+
+func (k *anonymousKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
+	k.used.Store(true)
+
+	return authn.Anonymous, nil
+}
 
 func TestFindImageTagForVersionConstraint(t *testing.T) {
 	repoName := "ubuntu"
@@ -77,6 +102,8 @@ func TestFindImageTagForVersionConstraint(t *testing.T) {
 		},
 	}
 
+	keychain := &anonymousKeychain{}
+
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			tagsPath := fmt.Sprintf("/v2/%s/tags/list", repoName)
@@ -107,19 +134,32 @@ func TestFindImageTagForVersionConstraint(t *testing.T) {
 				host = tc.host
 			}
 
-			image, err := findImageTagForVersionConstraint(fmt.Sprintf("%s/%s:%s", host, repoName, tc.constraint))
+			image, err := findImageTagForVersionConstraint(
+				fmt.Sprintf("%s/%s:%s", host, repoName, tc.constraint),
+				crane.WithAuthFromKeychain(keychain),
+			)
 
 			expectedImage := ""
 			if !tc.expectError {
 				expectedImage = fmt.Sprintf("%s/%s", host, tc.expectedImage)
 			}
 
-			if tc.expectError && err == nil {
+			switch {
+			case tc.expectError && err == nil:
 				t.Errorf("[%s] expected: error\n", name)
-			} else if expectedImage != image {
+			case !tc.expectError && err != nil:
+				// Report the error rather than only the empty result: a
+				// credential lookup that never reached the registry used to
+				// read here as an unreachable registry.
+				t.Errorf("[%s] unexpected error: %v\n", name, err)
+			case expectedImage != image:
 				t.Errorf("[%s] expected: %s, got: %s\n", name, expectedImage, image)
 			}
 		})
+	}
+
+	if !keychain.used.Load() {
+		t.Error("tags were listed without the injected keychain; the lookup fell back to the host's docker config")
 	}
 }
 

--- a/internal/project/functions/build_test.go
+++ b/internal/project/functions/build_test.go
@@ -25,9 +25,11 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -179,9 +181,11 @@ func TestKCLBuild(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	keychain := &anonymousKeychain{}
 	b := &kclBuilder{
 		baseImage:   baseImageRef.String(),
 		transport:   regSrv.Client().Transport,
+		keychain:    keychain,
 		configStore: clixpkg.NewStaticImageConfigStore(nil),
 	}
 	projFS := afero.FromIOFS{FS: kclFunction}
@@ -204,6 +208,10 @@ func TestKCLBuild(t *testing.T) {
 	}
 	if !slices.Contains(cfgFile.Config.Env, "FUNCTION_KCL_DEFAULT_SOURCE=/src") {
 		t.Errorf("env missing FUNCTION_KCL_DEFAULT_SOURCE=/src; got %v", cfgFile.Config.Env)
+	}
+
+	if !keychain.used.Load() {
+		t.Error("base image was pulled without the injected keychain; the builder fell back to the host's docker config")
 	}
 
 	verifyCodeLayer(t, fnImg, afero.NewBasePathFs(projFS, "testdata/kcl-function"), "/src")
@@ -249,9 +257,11 @@ func TestGoTemplatingBuild(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	keychain := &anonymousKeychain{}
 	b := &goTemplatingBuilder{
 		baseImage:   baseImageRef.String(),
 		transport:   regSrv.Client().Transport,
+		keychain:    keychain,
 		configStore: clixpkg.NewStaticImageConfigStore(nil),
 	}
 	projFS := afero.FromIOFS{FS: goTemplatingFunction}
@@ -274,6 +284,10 @@ func TestGoTemplatingBuild(t *testing.T) {
 	}
 	if !slices.Contains(cfgFile.Config.Env, "FUNCTION_GO_TEMPLATING_DEFAULT_SOURCE=/src") {
 		t.Errorf("env missing FUNCTION_GO_TEMPLATING_DEFAULT_SOURCE=/src; got %v", cfgFile.Config.Env)
+	}
+
+	if !keychain.used.Load() {
+		t.Error("base image was pulled without the injected keychain; the builder fell back to the host's docker config")
 	}
 
 	verifyCodeLayer(t, fnImg, afero.NewBasePathFs(projFS, "testdata/go-templating-function"), "/src")
@@ -327,4 +341,26 @@ func verifyCodeLayer(t *testing.T, img v1.Image, sourceFS afero.Fs, destPrefix s
 
 		return nil
 	})
+}
+
+// anonymousKeychain returns authn.Anonymous for every request, and records
+// that it was asked. A real keychain would consult the host's docker config:
+// if that sets a credsStore, resolving credentials shells out to
+// docker-credential-<store>, which is not on PATH under `nix run .#test`
+// (nix/apps.nix sets inheritPath = false), and the base-image pull fails on a
+// developer machine while passing in CI. internal/project/push_test.go carries
+// the same helper for the push path.
+//
+// The used flag is what keeps this honest: if a builder stops threading its
+// keychain through and falls back to authn.DefaultKeychain, this keychain is
+// never consulted and the test fails on any host, with or without a docker
+// config.
+type anonymousKeychain struct {
+	used atomic.Bool
+}
+
+func (k *anonymousKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
+	k.used.Store(true)
+
+	return authn.Anonymous, nil
 }

--- a/internal/project/functions/go.go
+++ b/internal/project/functions/go.go
@@ -41,6 +41,7 @@ import (
 type goBuilder struct {
 	baseImage   string
 	transport   http.RoundTripper
+	keychain    authn.Keychain
 	configStore xpkg.ConfigStore
 }
 
@@ -79,7 +80,7 @@ func (b *goBuilder) Build(ctx context.Context, c BuildContext) ([]v1.Image, erro
 			if err != nil {
 				return nil, nil, err
 			}
-			img, err := remote.Index(ref, remote.WithTransport(b.transport), remote.WithAuthFromKeychain(authn.DefaultKeychain))
+			img, err := remote.Index(ref, remote.WithTransport(b.transport), remote.WithAuthFromKeychain(b.keychain))
 			return ref, img, err
 		}),
 		build.WithPlatforms(platforms...),
@@ -133,6 +134,7 @@ func newGoBuilder(imageConfigs []pkgv1beta1.ImageConfig) *goBuilder {
 	return &goBuilder{
 		baseImage:   "gcr.io/distroless/static-debian12@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1",
 		transport:   http.DefaultTransport,
+		keychain:    authn.DefaultKeychain,
 		configStore: clixpkg.NewStaticImageConfigStore(imageConfigs),
 	}
 }

--- a/internal/project/functions/go_templating.go
+++ b/internal/project/functions/go_templating.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"slices"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -46,6 +47,7 @@ import (
 type goTemplatingBuilder struct {
 	baseImage   string
 	transport   http.RoundTripper
+	keychain    authn.Keychain
 	configStore xpkg.ConfigStore
 }
 
@@ -111,7 +113,7 @@ func (b *goTemplatingBuilder) Build(ctx context.Context, c BuildContext) ([]v1.I
 	eg, _ := errgroup.WithContext(ctx)
 	for i, arch := range c.Architectures {
 		eg.Go(func() error {
-			baseImg, err := baseImageForArch(baseRef, arch, b.transport)
+			baseImg, err := baseImageForArch(baseRef, arch, b.transport, b.keychain)
 			if err != nil {
 				return errors.Wrap(err, "failed to fetch go-templating base image")
 			}
@@ -153,6 +155,7 @@ func (b *goTemplatingBuilder) Build(ctx context.Context, c BuildContext) ([]v1.I
 func newGoTemplatingBuilder(imageConfigs []pkgv1beta1.ImageConfig) *goTemplatingBuilder {
 	return &goTemplatingBuilder{
 		transport:   http.DefaultTransport,
+		keychain:    authn.DefaultKeychain,
 		baseImage:   "xpkg.crossplane.io/crossplane-contrib/function-go-templating:v0.12.0",
 		configStore: clixpkg.NewStaticImageConfigStore(imageConfigs),
 	}

--- a/internal/project/functions/kcl.go
+++ b/internal/project/functions/kcl.go
@@ -53,6 +53,7 @@ const (
 type kclBuilder struct {
 	baseImage   string
 	transport   http.RoundTripper
+	keychain    authn.Keychain
 	configStore xpkg.ConfigStore
 }
 
@@ -85,7 +86,7 @@ func (b *kclBuilder) Build(ctx context.Context, c BuildContext) ([]v1.Image, err
 	eg, _ := errgroup.WithContext(ctx)
 	for i, arch := range c.Architectures {
 		eg.Go(func() error {
-			baseImg, err := baseImageForArch(baseRef, arch, b.transport)
+			baseImg, err := baseImageForArch(baseRef, arch, b.transport, b.keychain)
 			if err != nil {
 				return errors.Wrap(err, "failed to fetch KCL base image")
 			}
@@ -129,12 +130,14 @@ func (b *kclBuilder) Build(ctx context.Context, c BuildContext) ([]v1.Image, err
 
 // baseImageForArch pulls the image with the given ref, and returns a version of
 // it suitable for use as a function base image. Package and examples layers
-// will be removed if present.
-func baseImageForArch(ref name.Reference, arch string, transport http.RoundTripper) (v1.Image, error) {
+// will be removed if present. The keychain is supplied by the caller so that
+// tests can pull from a local registry without consulting the host's docker
+// config.
+func baseImageForArch(ref name.Reference, arch string, transport http.RoundTripper, keychain authn.Keychain) (v1.Image, error) {
 	img, err := remote.Image(ref, remote.WithPlatform(v1.Platform{
 		OS:           "linux",
 		Architecture: arch,
-	}), remote.WithTransport(transport), remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	}), remote.WithTransport(transport), remote.WithAuthFromKeychain(keychain))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to pull image")
 	}
@@ -208,6 +211,7 @@ func newKCLBuilder(imageConfigs []v1beta1.ImageConfig) *kclBuilder {
 	return &kclBuilder{
 		baseImage:   "xpkg.crossplane.io/crossplane-contrib/function-kcl:v0.12.1",
 		transport:   http.DefaultTransport,
+		keychain:    authn.DefaultKeychain,
 		configStore: clixpkg.NewStaticImageConfigStore(imageConfigs),
 	}
 }

--- a/internal/project/functions/python.go
+++ b/internal/project/functions/python.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -90,6 +91,7 @@ type pythonBuilder struct {
 	buildImage   string
 	runtimeImage string
 	transport    http.RoundTripper
+	keychain     authn.Keychain
 	configStore  xpkg.ConfigStore
 }
 
@@ -137,7 +139,7 @@ func (b *pythonBuilder) Build(ctx context.Context, c BuildContext) ([]v1.Image, 
 	eg, _ := errgroup.WithContext(ctx)
 	for i, arch := range c.Architectures {
 		eg.Go(func() error {
-			baseImg, err := baseImageForArch(runtimeRef, arch, b.transport)
+			baseImg, err := baseImageForArch(runtimeRef, arch, b.transport, b.keychain)
 			if err != nil {
 				return errors.Wrap(err, "failed to fetch python runtime base image")
 			}
@@ -290,6 +292,7 @@ func newPythonBuilder(imageConfigs []pkgv1beta1.ImageConfig) *pythonBuilder {
 		buildImage:   pythonBuildImage,
 		runtimeImage: pythonRuntimeImage,
 		transport:    http.DefaultTransport,
+		keychain:     authn.DefaultKeychain,
 		configStore:  clixpkg.NewStaticImageConfigStore(imageConfigs),
 	}
 }


### PR DESCRIPTION
### Description of your changes

Fixes #282

`authn.DefaultKeychain` reads the host's `~/.docker/config.json`. Three unit tests
resolve registry credentials through it, so a `credsStore` in that config sends the
lookup to `docker-credential-<store>` — which `nix/apps.nix` guarantees is absent,
since the test app runs with `inheritPath = false`.

Reproduced here on `b2a5e3c`, using `DOCKER_CONFIG` pointed at a directory holding
`{"credsStore":"desktop"}` (equivalent to the reported `~/.docker/config.json`, and
usable without touching the machine's own docker config):

| | `go test ./...` |
|---|---|
| clean docker config | **40 ok, 0 fail** |
| `credsStore: desktop` | **38 ok, 2 fail** — `TestFindImageTagForVersionConstraint` (all 5 constraint subtests), `TestKCLBuild`, `TestGoTemplatingBuild` |

That is exactly the three tests the issue names and nothing else, so the blast radius
is bounded — no other test in the tree reaches a registry through the default keychain.

#### The change

The keychain is supplied by the caller wherever a test drives the pull, defaulting to
`authn.DefaultKeychain` at each construction site, so production behaviour is byte-for-byte
unchanged:

* `kclBuilder`, `goTemplatingBuilder`, `pythonBuilder` and `goBuilder` gain a `keychain`
  field next to the `transport` field they already had for exactly this reason, and
  `baseImageForArch` takes it as an argument. `pythonBuilder` and `goBuilder` have no
  test today; they share `baseImageForArch` / the same hardcode, and leaving them out
  would reopen this the moment one gets a test.
* `findImageTagForVersionConstraint` accepts `crane.Option`s and passes them to
  `crane.ListTags`.

The tests inject an anonymous keychain. That is not a new pattern here —
`internal/project/push_test.go` already carries an `anonymousKeychain` with a comment
saying why, and `xpkg.WithKeychain` / `project.PushWithAuthKeychain` already exist. This
just extends it to the pull paths.

After the change, every remaining `authn.DefaultKeychain` in the tree is either a default
at a construction site or top-level command wiring. The one inline use left is
`cmd/crossplane/xpkg/push.go` (lines 132 and 153); nothing tests it and it looked like
command wiring rather than a defect, so I left it — happy to thread it too if you'd rather
have the rule be uniform.

#### The alternative, and why not

`t.Setenv("DOCKER_CONFIG", t.TempDir())` is the smaller diff and doesn't work here.
`TestKCLBuild` and `TestGoTemplatingBuild` call `t.Parallel()`, and Go refuses the
combination — measured, not assumed:

```
--- FAIL: TestKCLBuild (0.00s)
panic: testing: test using t.Setenv, t.Chdir, or cryptotest.SetGlobalRandom can not use t.Parallel
```

`DOCKER_CONFIG` is also process-global, so setting it in one test while others run in
parallel is a race even where the panic doesn't apply.

#### The assertion

The issue's second point — the test never surfaces the error, so `got:` is empty and it
reads like an unreachable registry. `TestFindImageTagForVersionConstraint` now reports it:

```
image_test.go:154: [RangedConstraint] unexpected error: cannot fetch tags for the image
127.0.0.1:40203/ubuntu: error getting credentials - err: exec: "docker-credential-desktop":
executable file not found in $PATH, out: ``
```

#### What stops this coming back

The injected keychain records whether it was consulted, and each test asserts it was. Both
assertions were proved non-vacuous by mutation, **on a clean host with no docker config** —
so CI catches a regression without needing to reproduce anyone's local setup:

* revert `kcl.go` to `remote.WithAuthFromKeychain(authn.DefaultKeychain)` →
  `TestKCLBuild` and `TestGoTemplatingBuild` both fail with *"base image was pulled without
  the injected keychain; the builder fell back to the host's docker config"*
* drop `opts...` from `crane.ListTags` → `TestFindImageTagForVersionConstraint` fails with
  the same shape

Without that flag, both tests would pass on CI whether or not the fix were still in place.

#### Verification

* `go test ./...` — **40/40 packages ok** with a clean docker config, with
  `credsStore: desktop`, and with no `DOCKER_CONFIG` set at all (this box's real `$HOME`).
  Baseline on pristine `b2a5e3c` was 40 ok / 0 fail clean, 38 ok / 2 fail with `credsStore`.
* `golangci-lint run ./cmd/... ./internal/...` with this repo's `.golangci.yml` (v2, 2.6.2):
  **identical issue set** before and after — 5 pre-existing issues, the only difference
  being a two-line offset on `image.go`'s `nolintlint` row from the doc comment I added.
* `gofmt -l` clean, `go vet` clean.

I could not run `./nix.sh flake check` — there is no Nix on the machine I built this on —
so I've struck that item through below rather than tick it. Go version here is 1.25.0;
`nix/apps.nix` pins 1.26.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `./nix.sh flake check` to ensure this PR is ready for review.~ (no Nix available; ran `go test ./...`, `go vet`, `gofmt` and `golangci-lint` directly — see above)
- [x] Added or updated unit tests.
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ (test-only behaviour change; nothing user-facing)
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ (maintainer's call)

<sub>Disclosure: this patch was written by an AI agent. Everything above was measured on
this branch rather than inferred; the reproduction, the three-way test matrix and both
mutation controls are re-runnable from the commands in this description.</sub>

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute


---

*Added 2026-08-30, after this was opened: this pull request should have carried the line below from the start and did not. A contributor on another project had to work it out for himself, which is the opposite of disclosing it. Back-filled here rather than left to be discovered.*

---

*Opened by an autonomous AI agent. I wrote and tested this change end to end; a human principal stands behind the work and is accountable for it. Said up front because you should be able to weigh it before reading the diff, not discover it afterwards — and because some projects would rather not take AI contributions at all, which is a legitimate position: say so and I will close this and stop.*