### PR TITLE
Add --[no-]default-mrap flag to project run

### DIFF
--- a/cmd/crossplane/project/help/run.md
+++ b/cmd/crossplane/project/help/run.md
@@ -17,6 +17,15 @@ multiple projects side-by-side.
 You can use a Crossplane version other than the latest stable version by
 specifying the `--crossplane-version` flag.
 
+By default Crossplane installs a wildcard `ManagedResourceActivationPolicy`,
+which activates the CRDs for every managed resource its providers offer. Pass
+`--no-default-mrap` to skip it, so the control plane activates only the managed
+resources your project declares its own activation policies for. This matches
+what a production control plane looks like when it manages activation
+explicitly. Like `--cluster-admin`, this flag applies only when `run` creates
+the control plane. A control plane that already runs Crossplane keeps its
+original settings, so run `crossplane project stop` first to change them.
+
 You can provide resources to apply around the project install:
 
 - `--init-resources` applies one or more files *before* installing the
@@ -42,6 +51,13 @@ Pin the Crossplane version installed in the dev control plane:
 
 ```shell
 crossplane project run --crossplane-version=v2.2.1
+```
+
+Run without the default wildcard activation policy, so only the project's own
+`ManagedResourceActivationPolicy` resources activate CRDs:
+
+```shell
+crossplane project run --no-default-mrap
 ```
 
 Apply `imageconfig.yaml` before installing the Configuration, and

--- a/cmd/crossplane/project/run.go
+++ b/cmd/crossplane/project/run.go
@@ -70,7 +70,8 @@ type runCmd struct {
 	ControlPlaneName  string        `help:"Name of the dev control plane. Defaults to project name."`
 	CrossplaneVersion string        `help:"Version of Crossplane to install."`
 	RegistryDir       string        `help:"Directory for local registry images."`
-	ClusterAdmin      bool          `default:"true"                                                  help:"Grant Crossplane the cluster-admin role." negatable:""`
+	ClusterAdmin      bool          `default:"true"                                                  help:"Grant Crossplane the cluster-admin role."                                               negatable:""`
+	DefaultMRAP       bool          `default:"true"                                                  help:"Install the default wildcard ManagedResourceActivationPolicy in the dev control plane." negatable:""`
 	Timeout           time.Duration `default:"5m"                                                    help:"Max wait for project readiness."`
 	InitResources     []string      `help:"Resources to apply before installing."                    type:"path"`
 	ExtraResources    []string      `help:"Resources to apply after installing."                     type:"path"`
@@ -218,6 +219,7 @@ func (c *runCmd) Run(logger logging.Logger, sp terminal.SpinnerPrinter, cfg *con
 				controlplane.WithCrossplaneVersion(c.CrossplaneVersion),
 				controlplane.WithRegistryDir(c.RegistryDir),
 				controlplane.WithClusterAdmin(c.ClusterAdmin),
+				controlplane.WithDefaultMRAP(c.DefaultMRAP),
 				controlplane.WithLogger(logger),
 			)
 			if ctpErr != nil {

--- a/internal/project/controlplane/controlplane.go
+++ b/internal/project/controlplane/controlplane.go
@@ -209,6 +209,7 @@ type config struct {
 	crossplaneVersion string
 	registryDir       string
 	clusterAdmin      bool
+	defaultMRAP       bool
 	log               logging.Logger
 }
 
@@ -240,6 +241,15 @@ func WithClusterAdmin(enabled bool) Option {
 	}
 }
 
+// WithDefaultMRAP sets whether to install the default wildcard
+// ManagedResourceActivationPolicy, which activates every managed resource CRD
+// in the control plane.
+func WithDefaultMRAP(enabled bool) Option {
+	return func(c *config) {
+		c.defaultMRAP = enabled
+	}
+}
+
 // WithLogger sets the logger for progress updates.
 func WithLogger(l logging.Logger) Option {
 	return func(c *config) {
@@ -252,6 +262,7 @@ func WithLogger(l logging.Logger) Option {
 func EnsureLocalDevControlPlane(ctx context.Context, opts ...Option) (DevControlPlane, error) { //nolint:gocyclo // Main orchestration function.
 	cfg := &config{
 		clusterAdmin: true,
+		defaultMRAP:  true,
 		log:          logging.NewNopLogger(),
 	}
 	for _, opt := range opts {
@@ -323,7 +334,7 @@ func EnsureLocalDevControlPlane(ctx context.Context, opts ...Option) (DevControl
 	}
 
 	cfg.log.Debug("Ensuring Crossplane is installed")
-	if err := ensureCrossplane(restConfig, cfg.crossplaneVersion, ca.Name, cfg.clusterAdmin); err != nil {
+	if err := ensureCrossplane(restConfig, cfg.crossplaneVersion, ca.Name, cfg.clusterAdmin, cfg.defaultMRAP); err != nil {
 		return nil, err
 	}
 
@@ -464,7 +475,7 @@ func createKindClusterConfig() *v1alpha4.Cluster {
 	}
 }
 
-func ensureCrossplane(restConfig *rest.Config, version, caConfigMap string, clusterAdmin bool) error {
+func ensureCrossplane(restConfig *rest.Config, version, caConfigMap string, clusterAdmin, defaultMRAP bool) error {
 	mgr, err := helm.NewManager(restConfig,
 		"crossplane",
 		"https://charts.crossplane.io/stable",
@@ -494,6 +505,15 @@ func ensureCrossplane(restConfig *rest.Config, version, caConfigMap string, clus
 		"rbac": map[string]any{
 			"clusterAdmin": clusterAdmin,
 		},
+	}
+	if !defaultMRAP {
+		// The chart defaults provider.defaultActivations to ["*"], which makes
+		// Crossplane create a wildcard ManagedResourceActivationPolicy. An
+		// explicit null removes the chart default during value coalescing, so
+		// no activations are passed and no default MRAP is created.
+		values["provider"] = map[string]any{
+			"defaultActivations": nil,
+		}
 	}
 	if err = mgr.Install(version, values); err != nil {
 		return errors.Wrap(err, "failed to install crossplane")


### PR DESCRIPTION
### Description of your changes

Adds a `--[no-]default-mrap` flag to `crossplane project run`, mirroring the flag of the same name in the `up` CLI.

Docs PR https://github.com/crossplane/docs/pull/1147

Crossplane's Helm chart defaults `provider.defaultActivations` to `["*"]`, so the local dev control plane always gets a wildcard `ManagedResourceActivationPolicy` activating every managed resource CRD its providers offer. That's a convenient default, but it doesn't match a production control plane that manages activation explicitly — a project can pass `project run` locally while its own activation policies are incomplete, and only fail once deployed.

`--no-default-mrap` sets `provider.defaultActivations` to `null` in the chart values. The chart template is a bare `range` over that value (`templates/deployment.yaml`), so an explicit null both removes the chart default during value coalescing and, failing that, ranges over nothing — either way no `--activation` args reach Crossplane and no default MRAP is created. Verified against chart v2.4.0:

```console
$ helm template cp crossplane --repo https://charts.crossplane.io/stable | grep -c activation
1
$ helm template cp crossplane --repo https://charts.crossplane.io/stable \
    --set-json 'provider.defaultActivations=null' | grep -c activation
0
```

The flag defaults to `true`, so existing behavior is unchanged.

Implementation follows the existing `--cluster-admin` pattern: a `WithDefaultMRAP` functional option on `controlplane.EnsureLocalDevControlPlane`, threaded into `ensureCrossplane`.

**Reviewer note:** `ensureCrossplane` returns early when Crossplane is already installed, so this flag — like `--cluster-admin` today — only takes effect when the control plane is created. Reusing an existing control plane keeps whatever it was built with. This is documented in `help/run.md`, but it's worth a look if you think the flag should instead force a reinstall or fail loudly on a mismatch.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review. <!-- nix not available locally; ran `go build ./...`, `go test ./...`, and `golangci-lint run` on the changed packages instead (all clean). -->
- [ ] ~Added or updated unit tests.~ <!-- `internal/project/controlplane` has no test suite; the change is a helm value pass-through with no logic to assert short of an integration test that stands up a kind cluster. Happy to add one if a reviewer would like. -->
- [x] ~Linked a PR or a [docs tracking issue] to [document this change].~ <!-- Flag is documented in the command's own `help/run.md`. -->
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ <!-- New feature, not a fix. -->

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet

