### PR TITLE
Propagate errors when probing for generated schemas

### DIFF
--- a/cmd/crossplane/function/generate.go
+++ b/cmd/crossplane/function/generate.go
@@ -303,7 +303,10 @@ type pythonTemplateData struct {
 }
 
 func (c *generateCmd) generatePythonFiles(targetFS afero.Fs) error {
-	hasSchemas, _ := afero.DirExists(c.schemasFS, "python")
+	hasSchemas, err := afero.DirExists(c.schemasFS, "python")
+	if err != nil {
+		return errors.Wrap(err, "cannot inspect python schemas directory")
+	}
 	if hasSchemas {
 		entries, err := afero.ReadDir(c.schemasFS, "python")
 		if err != nil {
@@ -368,7 +371,10 @@ func (c *generateCmd) generateGoFiles(fs afero.Fs) error {
 
 	var imports []goImport
 	schemasGoPath := filepath.Join(relRoot, c.proj.Spec.Paths.Schemas, "go")
-	hasSchemas, _ := afero.DirExists(c.schemasFS, "go")
+	hasSchemas, err := afero.DirExists(c.schemasFS, "go")
+	if err != nil {
+		return errors.Wrap(err, "cannot inspect go schemas directory")
+	}
 	if hasSchemas {
 		imports = []goImport{{
 			Module:  "dev.crossplane.io/models",
@@ -395,9 +401,11 @@ type goTemplatingTemplateData struct {
 
 func (c *generateCmd) generateGoTemplatingFiles(fs afero.Fs) error {
 	var modelPath string
-	indexExists, _ := afero.Exists(c.schemasFS, "json/index.schema.json")
+	indexExists, err := afero.Exists(c.schemasFS, "json/index.schema.json")
+	if err != nil {
+		return errors.Wrap(err, "cannot inspect json schema index")
+	}
 	if indexExists {
-		var err error
 		modelPath, err = filepath.Rel(c.fsPath, "schemas/json/index.schema.json")
 		if err != nil {
 			return errors.Wrap(err, "cannot determine model path")

--- a/internal/project/functions/python.go
+++ b/internal/project/functions/python.go
@@ -185,7 +185,10 @@ func (b *pythonBuilder) buildVenv(ctx context.Context, c BuildContext) (map[stri
 
 	pySchemasRel := path.Join(c.SchemasPath, "python")
 	pySchemasFS := afero.NewBasePathFs(c.ProjectFS, pySchemasRel)
-	hasPySchemas, _ := afero.DirExists(pySchemasFS, ".")
+	hasPySchemas, err := afero.DirExists(pySchemasFS, ".")
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot check for python schemas at %q", pySchemasRel)
+	}
 	var schemasTar []byte
 	if hasPySchemas {
 		schemasTar, err = filesystem.FSToTar(pySchemasFS, pySchemasRel)


### PR DESCRIPTION
### Description of your changes

Four probes for a generated schemas directory discarded their error and treated the failure as "no schemas". An unreadable schemas directory therefore produced a silently degraded result instead of an error:

| Location | Silent failure |
|---|---|
| `generatePythonFiles` | Scaffolds a function without the local schema dependency |
| `generateGoFiles` | Omits the `dev.crossplane.io/models` replace directive |
| `generateGoTemplatingFiles` | Omits the model index path |
| `pythonBuilder.buildVenv` | Builds an image without the project's python schemas |

In each case the user sees the real fault much later and in a misleading form — generated code that doesn't compile, or a function image missing its models — with nothing pointing at the schemas directory.

`afero.DirExists` and `afero.Exists` already report a missing directory as `(false, nil)`, so a non-nil error here is a genuine I/O or permission fault and is worth surfacing rather than discarding.

Found while reviewing feedback on #170, which flags the same pattern in the TypeScript paths that PR introduces. Those instances live in code that only exists on that branch, so they're fixed there; this PR covers the pre-existing ones on `main`.

### Deliberately not changed

`internal/schemas/generator/python.go:769` uses the same `if exists, _ := afero.Exists(...)` shape when creating `__init__.py` files, but the error is not truly lost there: a failing probe falls through to `afero.WriteFile`, which reports its own wrapped error. Happy to include it if a reviewer would rather have it consistent.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review. <!-- nix not available locally; ran `go build ./...`, `go test ./...`, and `golangci-lint run` on the changed packages instead (all clean). -->
- [ ] ~Added or updated unit tests.~ <!-- These are error paths on filesystem probes that only fail on I/O or permission faults; reaching them in a test needs an injected failing afero.Fs, which the surrounding packages have no fixture for today. Happy to add one if a reviewer would like. -->
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~ <!-- No user-facing behavior change beyond improved error reporting. -->
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~ <!-- Can add if maintainers want this on a release branch. -->

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
