### PR TITLE
contributing: Explicitly mention the Crossplane AI policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,12 @@ Please start by reading the [Crossplane contributing document]. The Crossplane
 CLI follows the same guidelines and policies as the core Crossplane project,
 including coding style. We also use a similar Nix-based development environment.
 
+In particular, we follow Crossplane's [AI policy]. AI usage is assumed and
+encouraged when working on the Crossplane CLI, but please familiarize yourself
+with the policy to ensure you are engaging respectfully with the project and its
+maintainers. As outlined in the policy, maintainers may summarily close pull
+requests and issues that do not meet the guidelines.
+
 The CLI maintainers primarily communicate in the [#sig-cli] channel on Slack.
 
 Topics specific to CLI development are covered below.
@@ -119,6 +125,7 @@ matches rather than whole rules, and rules rather than whole styles.
 <!-- Named links -->
 
 [Crossplane contributing document]: https://github.com/crossplane/crossplane/tree/main/contributing
+[AI policy]: https://github.com/crossplane/crossplane/tree/main/AI_POLICY.md
 [#sig-cli]: https://crossplane.slack.com/archives/C08V9PMLRQA
 [kong]: https://pkg.go.dev/github.com/alecthomas/kong
 [struct tags]: https://pkg.go.dev/github.com/alecthomas/kong#readme-supported-tags


### PR DESCRIPTION
### Description of your changes

Crossplane now has a formal policy about AI usage. Call it out explicitly in our contributing docs so users (and their agents) are more likely to read it before contributing.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `./nix.sh flake check` to ensure this PR is ready for review.
~- [ ] Added or updated unit tests.~
~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~
~- [ ] Added `backport release-x.y` labels to auto-backport this PR.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
