### PR TITLE
Generate compiling models for formatted string fields

### DIFF
--- a/internal/schemas/generator/go.go
+++ b/internal/schemas/generator/go.go
@@ -214,6 +214,7 @@ import (
 	"time"
 
 	"github.com/oapi-codegen/runtime"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	{{- range .ExternalImports}}
 	{{ . }}
@@ -229,6 +230,7 @@ var (
 	_ json.RawMessage = nil
 	_ = fmt.Errorf
 	_ = runtime.JSONMerge
+	_ openapi_types.Email
 )
 `
 

--- a/internal/schemas/generator/runtimeobject.go
+++ b/internal/schemas/generator/runtimeobject.go
@@ -35,6 +35,10 @@ const (
 	roRuntimeAlias  = "k8sruntime"
 	roRuntimeImport = "k8s.io/apimachinery/pkg/runtime"
 	roSchemaImport  = "k8s.io/apimachinery/pkg/runtime/schema"
+
+	// roOpenAPITypesAlias is the alias oapi-codegen uses for its formatted
+	// string types (Email, Date, File, UUID).
+	roOpenAPITypesAlias = "openapi_types"
 )
 
 // roScalarSelectorTypes are k8s types referenced via a package selector that are
@@ -216,7 +220,11 @@ func classifyElem(e ast.Expr, structs map[string]bool) fieldKind {
 		// pkg.Type — time.* and known alias types (Time, MicroTime, FieldsV1)
 		// are scalars; every other referenced package type is a generated struct
 		// with a DeepCopyInto method.
-		if pkg, ok := x.X.(*ast.Ident); ok && pkg.Name == "time" {
+		if pkg, ok := x.X.(*ast.Ident); ok && (pkg.Name == "time" || pkg.Name == roOpenAPITypesAlias) {
+			// oapi-codegen emits openapi_types.Email, Date, File and UUID for
+			// formatted strings. None of them has a DeepCopyInto method:
+			// Email is a string, UUID is an array, Date wraps a time.Time and
+			// File holds unexported fields. They copy by value.
 			return fkScalar
 		}
 		if roScalarSelectorTypes[x.Sel.Name] {

--- a/internal/schemas/generator/testdata/account_scaffold_definition.yaml
+++ b/internal/schemas/generator/testdata/account_scaffold_definition.yaml
@@ -35,6 +35,13 @@ spec:
                       type: string
                       description: |
                         The name of the account to be scaffolded.
+                    members:
+                      type: array
+                      description: |
+                        Member principals for the account.
+                      items:
+                        type: string
+                        format: email
                   required:
                     - name
               required:


### PR DESCRIPTION
### Description of your changes

An XRD field with a string format oapi-codegen maps to its own type, `format: email` being the case in #312, produces models that do not compile. Two separate reasons:

1. `goImportsTemplate` trims the default oapi-codegen imports down to the ones we use, and `openapi_types "github.com/oapi-codegen/runtime/types"` is not among them, so `openapi_types.Email` is undefined.
2. `classifyElem` treats any `pkg.Type` selector that is not `time.*` or one of the known k8s aliases as a struct with a `DeepCopyInto` method, so the DeepCopy generator emits `(*in)[i].DeepCopyInto(&(*out)[i])` for it. None of the four types in that package has such a method: `Email` is a string, `UUID` is an array alias, `Date` wraps a `time.Time`, and `File` holds unexported fields. They all copy by value.

The import is added to the template with a matching entry in the unused-import guard block, and the whole `openapi_types` package joins `time` in the scalar branch of `classifyElem`. No change to the generated module's `go.mod`, since `github.com/oapi-codegen/runtime` is already required and `runtime/types` is part of it.

Fixes #312

### I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.

### How has this code been tested?

`account_scaffold_definition.yaml` gains a `members` array of `format: email`, which is the shape from the issue, so the generated package now exercises the path.

I dumped the generated models both ways to see the two defects rather than infer them. Before the change, `xaccountscaffold.go` imports no `openapi_types` at all and its DeepCopy reads

```go
*out = make([]openapi_types.Email, len(*in))
for i := range *in {
    (*in)[i].DeepCopyInto(&(*out)[i])
}
```

After it, the import is present and the same block is `copy(*out, *in)`.

`go test ./internal/schemas/...` passes, and so does the real gate, `go test -tags compilegate -run TestGeneratedRuntimeObjectsCompile ./internal/schemas/generator/`, which materializes the module and builds it with the toolchain. That one fails on the current code with the new testdata field, which is the point of it.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing